### PR TITLE
Fix layout shift when sync status appears/disappears

### DIFF
--- a/shared.css
+++ b/shared.css
@@ -292,6 +292,8 @@ h1 {
     font-size: 0.75em;
     font-weight: 500;
     color: #888;
+    min-width: 50px;
+    text-align: right;
 }
 
 .sync-status.syncing { color: var(--color-sync-syncing); }


### PR DESCRIPTION
Add min-width to sync-status so it reserves space and doesn't cause nav to jump