### PR TITLE
Add page fade-in animation to smooth page load

### DIFF
--- a/shared.css
+++ b/shared.css
@@ -1,6 +1,16 @@
 /* Sports Card Checklists - Shared Styles */
 @import url('https://fonts.googleapis.com/css2?family=Bebas+Neue&family=Barlow:wght@400;500;600;700&display=swap');
 
+/* Smooth page load - fade in after fonts/styles settle */
+@keyframes pageFadeIn {
+    from { opacity: 0; }
+    to { opacity: 1; }
+}
+
+html {
+    animation: pageFadeIn 0.3s ease-out 0.1s both;
+}
+
 /* ============================================
    CSS Custom Properties (Theme Variables)
    Override these in page-specific styles


### PR DESCRIPTION
## Summary
- Adds a subtle fade-in animation (0.3s, 0.1s delay) to the html element
- Masks visual jumpiness during initial page load as fonts and JS execute

## Test plan
- [ ] Open any checklist page and observe smooth fade-in on load
- [ ] Hard refresh with Cmd+Shift+R to see the effect clearly
- [ ] Verify the page doesn't feel delayed (0.1s is imperceptible)