### PR TITLE
Update index page to use shared nav bar

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,8 +4,8 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Mike's Sports Card Checklists</title>
+    <link rel="stylesheet" href="shared.css">
     <style>
-        @import url('https://fonts.googleapis.com/css2?family=Bebas+Neue&family=Barlow:wght@400;500;600&display=swap');
 
         * { box-sizing: border-box; margin: 0; padding: 0; }
         body {
@@ -242,45 +242,6 @@
             font-size: 0.6em;
             color: #666;
         }
-        .auth-bar {
-            display: flex;
-            justify-content: flex-end;
-            align-items: center;
-            gap: 10px;
-            margin-bottom: 20px;
-            padding: 10px 15px;
-            background: rgba(255,255,255,0.05);
-            border-radius: 8px;
-        }
-        .auth-bar .user-info {
-            display: flex;
-            align-items: center;
-            gap: 8px;
-            color: #aaa;
-            font-size: 0.85em;
-        }
-        .auth-bar .user-info img {
-            width: 24px;
-            height: 24px;
-            border-radius: 50%;
-        }
-        .auth-bar button {
-            padding: 8px 16px;
-            border-radius: 6px;
-            border: none;
-            cursor: pointer;
-            font-size: 0.85em;
-            background: #238636;
-            color: white;
-        }
-        .auth-bar button:hover { background: #2ea043; }
-        .auth-bar button.logout { background: #444; }
-        .auth-bar button.logout:hover { background: #555; }
-        .auth-bar .note {
-            color: #666;
-            font-size: 0.75em;
-        }
-
         /* Aggregate Stats Section - "Championship Scoreboard" */
         .aggregate-stats {
             background:
@@ -397,11 +358,30 @@
     </style>
 </head>
 <body>
-    <div class="container">
-        <div class="auth-bar" id="auth-bar" style="display: none;">
-            <div id="auth-content"></div>
+    <nav class="nav-bar">
+        <div class="nav-inner">
+            <a href="index.html" class="nav-brand active" title="All Checklists">
+                <svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+                    <rect x="3" y="3" width="8" height="11" rx="1" opacity="0.7"/>
+                    <rect x="13" y="3" width="8" height="11" rx="1"/>
+                    <rect x="3" y="16" width="18" height="5" rx="1" opacity="0.4"/>
+                </svg>
+                <span class="nav-brand-text">MIKE'S CARDS</span>
+            </a>
+            <div class="nav-divider"></div>
+            <div class="nav-links">
+                <a href="jayden-daniels-rookie-checklist.html" class="nav-link">JAYDEN DANIELS</a>
+                <a href="washington-qbs-rookie-checklist.html" class="nav-link">WASHINGTON QBS</a>
+                <a href="jmu-pro-players-checklist.html" class="nav-link">JMU PROS</a>
+            </div>
+            <div class="nav-auth">
+                <span class="sync-status" id="sync-status"></span>
+                <div id="auth-content"></div>
+            </div>
         </div>
+    </nav>
 
+    <div class="container">
         <div class="logo-container">
             <div class="logo-mark">
                 <span class="logo-card left"></span>
@@ -516,20 +496,18 @@
     <script src="shared.js"></script>
     <script>
         function updateAuthUI() {
-            const authBar = document.getElementById('auth-bar');
             const authContent = document.getElementById('auth-content');
             if (githubSync.isLoggedIn()) {
                 const user = githubSync.getUser();
-                authBar.style.display = 'flex';
                 authContent.innerHTML = `
-                    <span class="user-info">
+                    <div class="nav-user">
                         <img src="${user.avatar_url}" alt="">
-                        ${user.login}
-                    </span>
-                    <button class="logout" onclick="logout()">Sign out</button>
+                        <span>${user.login}</span>
+                    </div>
+                    <button class="nav-btn logout" onclick="logout()">Sign out</button>
                 `;
             } else {
-                authBar.style.display = 'none';
+                authContent.innerHTML = '';
             }
         }
 


### PR DESCRIPTION
## Summary
- Import shared.css for consistent nav styling and page fade-in animation
- Replace old auth-bar with new broadcast ticker nav bar design
- Remove duplicate inline auth-bar styles
- Update updateAuthUI to use new nav classes (nav-user, nav-btn)

Fixes the auth bar display issue on the index page and adds the page fade-in smoothing.

## Test plan
- [ ] Index page loads with smooth fade-in animation
- [ ] Nav bar displays correctly with links to all checklists
- [ ] Auth section shows user avatar and name inline (not stacked)
- [ ] Sign out button displays correctly