### PR TITLE
Center nav links in nav bar

### DIFF
--- a/shared.css
+++ b/shared.css
@@ -186,7 +186,9 @@ h1 {
 .nav-links {
     display: flex;
     align-items: center;
+    justify-content: center;
     gap: 4px;
+    flex: 1;
 }
 
 .nav-link {


### PR DESCRIPTION
Add flex: 1 and justify-content: center to .nav-links so checklist links are centered between brand and auth.