### PR TITLE
Fix nav links centering and remove stray divider

### DIFF
--- a/shared.css
+++ b/shared.css
@@ -178,10 +178,7 @@ h1 {
 }
 
 .nav-divider {
-    width: 1px;
-    height: 28px;
-    background: linear-gradient(180deg, transparent, rgba(255,255,255,0.15), transparent);
-    margin: 0 8px;
+    display: none;
 }
 
 .nav-links {


### PR DESCRIPTION
## Summary
- Use absolute positioning to truly center nav links in the navbar
- Hide the nav-divider element that was appearing in the wrong spot and overlapping text on some pages

## Test plan
- [ ] Verify nav links are centered on all pages
- [ ] Verify no stray vertical bar appears between/over links
- [ ] Check on index, Jayden Daniels, Washington QBs, and JMU Pros pages