### PR TITLE
Fix vertical alignment of stat pill numbers

### DIFF
--- a/index.html
+++ b/index.html
@@ -233,6 +233,7 @@
             font-family: 'Bebas Neue', sans-serif;
             font-size: 1.1em;
             color: #888;
+            transform: translateY(1px);
         }
         .coming-soon {
             opacity: 0.5;


### PR DESCRIPTION
Nudge Bebas Neue numbers down 1px to align with Barlow text in stat pills.