### PR TITLE
Hide logo cards on small viewports

### DIFF
--- a/index.html
+++ b/index.html
@@ -349,6 +349,7 @@
         .aggregate-stat-breakdown .needed { color: #ff9800; }
 
         @media (max-width: 500px) {
+            .logo-card { display: none; }
             .aggregate-stats { padding: 20px 16px 16px; }
             .aggregate-stats-grid {
                 grid-template-columns: 1fr;


### PR DESCRIPTION
Hide decorative card logos on mobile (≤500px) where they looked cramped.

Closes #89