### PR TITLE
Add Content Security Policy to all pages

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,6 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; img-src 'self' https: data:; font-src 'self' https://fonts.gstatic.com; connect-src 'self' https://api.github.com https://cards-oauth.iammikec.workers.dev;">
     <title>Mike's Sports Card Checklists</title>
     <link rel="stylesheet" href="shared.css">
     <style>

--- a/jayden-daniels-rookie-checklist.html
+++ b/jayden-daniels-rookie-checklist.html
@@ -3,6 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; img-src 'self' https: data:; font-src 'self' https://fonts.gstatic.com; connect-src 'self' https://api.github.com https://cards-oauth.iammikec.workers.dev;">
     <title>Jayden Daniels Rookie Card Checklist</title>
     <link rel="stylesheet" href="shared.css">
     <style>

--- a/jmu-pro-players-checklist.html
+++ b/jmu-pro-players-checklist.html
@@ -3,6 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; img-src 'self' https: data:; font-src 'self' https://fonts.gstatic.com; connect-src 'self' https://api.github.com https://cards-oauth.iammikec.workers.dev;">
     <title>JMU Pro Players Card Checklist</title>
     <link rel="stylesheet" href="shared.css">
     <style>

--- a/washington-qbs-rookie-checklist.html
+++ b/washington-qbs-rookie-checklist.html
@@ -3,6 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; img-src 'self' https: data:; font-src 'self' https://fonts.gstatic.com; connect-src 'self' https://api.github.com https://cards-oauth.iammikec.workers.dev;">
     <title>Washington Redskins/Commanders QB Rookie Cards (1982-2025)</title>
     <link rel="stylesheet" href="shared.css">
     <style>


### PR DESCRIPTION
## Summary
Adds CSP meta tag to all 4 HTML pages, restricting:
- Scripts: self + inline only
- Styles: self + inline + Google Fonts
- Images: self + any https + data URIs
- Fonts: self + Google Fonts
- API calls: self + GitHub API + Cloudflare Worker

Defense-in-depth against XSS.

Closes #72