### PR TITLE
Performance improvements: lazy loading and DOM query optimization

### DIFF
--- a/jayden-daniels-rookie-checklist.html
+++ b/jayden-daniels-rookie-checklist.html
@@ -344,12 +344,13 @@
         function updateStats() {
             // Exclude chase and insert cards from main stats
             const mainCards = document.querySelectorAll('.default-section:not(.inserts-section .default-section) .card:not([style*="display: none"]), #sorted-section .card:not([style*="display: none"])');
-            const ownedVisible = document.querySelectorAll('.default-section:not(.inserts-section .default-section) .card.owned:not([style*="display: none"]), #sorted-section .card.owned:not([style*="display: none"])').length;
-            let totalValue = 0, ownedValue = 0, neededValue = 0;
+            let ownedVisible = 0, totalValue = 0, ownedValue = 0, neededValue = 0;
             mainCards.forEach(c => {
                 const price = parseFloat(c.dataset.price);
+                const isOwned = c.classList.contains('owned');
                 totalValue += price;
-                if (c.classList.contains('owned')) {
+                if (isOwned) {
+                    ownedVisible++;
                     ownedValue += price;
                 } else {
                     neededValue += price;
@@ -411,7 +412,7 @@
                     <div class="card-image-wrapper">
                         <span class="price-badge ${priceClass}">$${Math.max(1, Math.round(price))}</span>
                         ${card.img
-                            ? `<a href="${searchUrl}" target="_blank"><img class="card-image" src="${card.img}" alt="${card.set}" onerror="this.outerHTML='<a href=\\'${searchUrl}\\' target=\\'_blank\\' class=\\'card-image placeholder\\'>Click to view</a>'"></a>`
+                            ? `<a href="${searchUrl}" target="_blank"><img class="card-image" src="${card.img}" alt="${card.set}" loading="lazy" onerror="this.outerHTML='<a href=\\'${searchUrl}\\' target=\\'_blank\\' class=\\'card-image placeholder\\'>Click to view</a>'"></a>`
                             : `<a href="${searchUrl}" target="_blank" class="card-image placeholder">Click to view on eBay</a>`
                         }
                     </div>

--- a/jmu-pro-players-checklist.html
+++ b/jmu-pro-players-checklist.html
@@ -978,12 +978,13 @@
         function updateStats() {
             // Only count main cards, not alternates
             const mainCards = document.querySelectorAll('.card:not([style*="display: none"]):not(#alternates-cards .card)');
-            const ownedMain = document.querySelectorAll('.card.owned:not([style*="display: none"]):not(#alternates-cards .card)').length;
-            let totalValue = 0, ownedValue = 0, neededValue = 0;
+            let ownedMain = 0, totalValue = 0, ownedValue = 0, neededValue = 0;
             mainCards.forEach(c => {
                 const price = parseFloat(c.dataset.price);
+                const isOwned = c.classList.contains('owned');
                 totalValue += price;
-                if (c.classList.contains('owned')) {
+                if (isOwned) {
+                    ownedMain++;
                     ownedValue += price;
                 } else {
                     neededValue += price;
@@ -1036,7 +1037,7 @@
                     <div class="card-image-wrapper">
                         <span class="price-badge ${priceClass}">$${Math.round(price)}</span>
                         ${card.img
-                            ? `<a href="${searchUrl}" target="_blank"><img class="card-image" src="${card.img}" alt="${card.set}" onerror="this.outerHTML='<a href=\\'${searchUrl}\\' target=\\'_blank\\' class=\\'card-image placeholder\\'>Click to view</a>'"></a>`
+                            ? `<a href="${searchUrl}" target="_blank"><img class="card-image" src="${card.img}" alt="${card.set}" loading="lazy" onerror="this.outerHTML='<a href=\\'${searchUrl}\\' target=\\'_blank\\' class=\\'card-image placeholder\\'>Click to view</a>'"></a>`
                             : `<a href="${searchUrl}" target="_blank" class="card-image placeholder">Click to view on eBay</a>`
                         }
                     </div>

--- a/washington-qbs-rookie-checklist.html
+++ b/washington-qbs-rookie-checklist.html
@@ -595,9 +595,9 @@
                     <div class="card-image-wrapper">
                         <span class="collection-badge">${jdBadge}</span>
                         <div class="card-stack">
-                            <img src="jayden-daniels-cards/card_00_wm8AAeSw.webp" alt="">
-                            <img src="jayden-daniels-cards/card_03_MuMAAOSw.webp" alt="">
-                            <img src="jayden-daniels-cards/resurgence_196.webp" alt="">
+                            <img src="jayden-daniels-cards/card_00_wm8AAeSw.webp" alt="" loading="lazy">
+                            <img src="jayden-daniels-cards/card_03_MuMAAOSw.webp" alt="" loading="lazy">
+                            <img src="jayden-daniels-cards/resurgence_196.webp" alt="" loading="lazy">
                         </div>
                     </div>
                     <div class="player-name">${qb.name}</div>
@@ -614,7 +614,7 @@
                 <div class="card-image-wrapper">
                     ${qb.superBowl ? '<span class="super-bowl-badge">SUPER BOWL</span>' : ''}
                     <span class="price-badge">$${Math.max(1, Math.round(qb.price))}</span>
-                    <img class="card-image" src="${qb.img}" alt="${qb.name}" onerror="this.style.display='none'">
+                    <img class="card-image" src="${qb.img}" alt="${qb.name}" loading="lazy" onerror="this.style.display='none'">
                 </div>
                 <div class="player-name">${qb.name}</div>
                 <div class="player-years">${qb.years} &bull; ${qb.record}</div>
@@ -699,13 +699,14 @@
             const visibleQbs = filteredQbs || qbs;
             // Exclude collection link cards from counts
             const countableQbs = visibleQbs.filter(qb => !qb.collectionLink);
-            const ownedCount = countableQbs.filter(qb => isOwned(getCardId(qb))).length;
             const totalCount = countableQbs.length;
-            let totalValue = 0, ownedValue = 0, neededValue = 0;
+            let ownedCount = 0, totalValue = 0, ownedValue = 0, neededValue = 0;
             countableQbs.forEach(qb => {
                 const price = qb.price || 0;
+                const owned = isOwned(getCardId(qb));
                 totalValue += price;
-                if (isOwned(getCardId(qb))) {
+                if (owned) {
+                    ownedCount++;
                     ownedValue += price;
                 } else {
                     neededValue += price;


### PR DESCRIPTION
## Summary
- **Lazy loading (#82)**: Add `loading="lazy"` to all card images - browser won't load images below the fold until needed
- **DOM query optimization (#83)**: Reduce queries in `updateStats()` by counting owned cards during the existing forEach instead of a second querySelectorAll

## Impact
- Faster initial page load (fewer images loaded upfront)
- Faster stats updates (1 DOM query instead of 2)

Closes #82, closes #83