### PR TITLE
Fix data sync issues: race condition and multi-tab cache

### DIFF
--- a/github-sync.js
+++ b/github-sync.js
@@ -22,6 +22,13 @@ class GitHubSync {
         this.onAuthChange = null;
         this._saveQueue = Promise.resolve(); // Queue to prevent concurrent saves
         this._cachedData = null; // Cache to avoid stale reads during saves
+
+        // Clear cache when tab becomes visible (handles multi-tab edits)
+        document.addEventListener('visibilitychange', () => {
+            if (document.visibilityState === 'visible') {
+                this._cachedData = null;
+            }
+        });
     }
 
     isLoggedIn() {

--- a/jayden-daniels-rookie-checklist.html
+++ b/jayden-daniels-rookie-checklist.html
@@ -322,7 +322,8 @@
             checklistId: 'jayden-daniels',
             ownerUsername: 'iammike',
             localStorageKey: 'jaydenDanielsOwned',
-            onOwnedChange: () => { renderCards(); updateStats(); }
+            onOwnedChange: () => { renderCards(); updateStats(); },
+            getStats: () => computeStats()
         });
 
         // Use shared utilities
@@ -341,48 +342,48 @@
             FilterUtils.applyFilters({ onFilter: updateStats });
         }
 
-        function updateStats() {
-            // Exclude chase and insert cards from main stats
+        // Compute stats for display and saving (used by both updateStats and getStats callback)
+        function computeStats() {
             const mainCards = document.querySelectorAll('.default-section:not(.inserts-section .default-section) .card:not([style*="display: none"]), #sorted-section .card:not([style*="display: none"])');
             let ownedVisible = 0, totalValue = 0, ownedValue = 0, neededValue = 0;
             mainCards.forEach(c => {
                 const price = parseFloat(c.dataset.price);
-                const isOwned = c.classList.contains('owned');
+                const owned = c.classList.contains('owned');
                 totalValue += price;
-                if (isOwned) {
+                if (owned) {
                     ownedVisible++;
                     ownedValue += price;
                 } else {
                     neededValue += price;
                 }
             });
-
-            // Count inserts and chase (from card arrays, not DOM, for accuracy)
             const ownedInserts = cards.inserts.filter(c => isOwned(getCardId(c))).length;
             const ownedChase = cards.chase.filter(c => isOwned(getCardId(c))).length;
 
+            return {
+                owned: ownedVisible,
+                total: mainCards.length,
+                ownedValue: Math.round(ownedValue),
+                neededValue: Math.round(neededValue),
+                insertsOwned: ownedInserts,
+                insertsTotal: cards.inserts.length,
+                chaseOwned: ownedChase,
+                chaseTotal: cards.chase.length
+            };
+        }
+
+        function updateStats() {
+            const stats = computeStats();
+
             // Animate stats on first load
             StatsAnimator.animateStats({
-                owned: { el: document.getElementById('owned-count'), value: ownedVisible },
-                total: { el: document.getElementById('total-count'), value: mainCards.length },
-                totalValue: { el: document.getElementById('total-value'), value: Math.round(totalValue) },
-                ownedValue: { el: document.getElementById('owned-value'), value: Math.round(ownedValue) },
-                neededValue: { el: document.getElementById('needed-value'), value: Math.round(neededValue) }
+                owned: { el: document.getElementById('owned-count'), value: stats.owned },
+                total: { el: document.getElementById('total-count'), value: stats.total },
+                totalValue: { el: document.getElementById('total-value'), value: stats.ownedValue + stats.neededValue },
+                ownedValue: { el: document.getElementById('owned-value'), value: stats.ownedValue },
+                neededValue: { el: document.getElementById('needed-value'), value: stats.neededValue }
             });
-
-            // Save stats for index page to read (gist is source of truth)
-            if (window.githubSync && githubSync.isLoggedIn()) {
-                githubSync.saveChecklistStats('jayden-daniels', {
-                    owned: ownedVisible,
-                    total: mainCards.length,
-                    ownedValue: Math.round(ownedValue),
-                    neededValue: Math.round(neededValue),
-                    insertsOwned: ownedInserts,
-                    insertsTotal: cards.inserts.length,
-                    chaseOwned: ownedChase,
-                    chaseTotal: cards.chase.length
-                });
-            }
+            // Stats are now saved atomically with owned cards via getStats callback
         }
 
         function toggleChaseSection() {

--- a/jmu-pro-players-checklist.html
+++ b/jmu-pro-players-checklist.html
@@ -938,7 +938,8 @@
             checklistId: 'jmu-pro-players',
             ownerUsername: 'iammike',
             localStorageKey: 'jmuProPlayersOwned',
-            onOwnedChange: () => { renderCards(); updateStats(); }
+            onOwnedChange: () => { renderCards(); updateStats(); },
+            getStats: () => computeStats()
         });
 
         // Custom getCardId includes player name for JMU
@@ -975,47 +976,47 @@
             updateStats();
         }
 
-        function updateStats() {
-            // Only count main cards, not alternates
+        // Compute stats for saving (used by both updateStats and getStats callback)
+        function computeStats() {
             const mainCards = document.querySelectorAll('.card:not([style*="display: none"]):not(#alternates-cards .card)');
             let ownedMain = 0, totalValue = 0, ownedValue = 0, neededValue = 0;
             mainCards.forEach(c => {
                 const price = parseFloat(c.dataset.price);
-                const isOwned = c.classList.contains('owned');
+                const owned = c.classList.contains('owned');
                 totalValue += price;
-                if (isOwned) {
+                if (owned) {
                     ownedMain++;
                     ownedValue += price;
                 } else {
                     neededValue += price;
                 }
             });
-
-            // Count alternates (extras) from all card arrays
             const allCards = [...cards.hof, ...cards.probowl, ...cards.usfl, ...cards.modern, ...cards.mlb, ...cards.nba, ...cards.mls];
             const alternates = allCards.filter(c => c.alternate);
             const ownedAlternates = alternates.filter(c => isOwned(getCardId(c))).length;
 
+            return {
+                owned: ownedMain,
+                total: mainCards.length,
+                ownedValue: Math.round(ownedValue),
+                neededValue: Math.round(neededValue),
+                extrasOwned: ownedAlternates,
+                extrasTotal: alternates.length
+            };
+        }
+
+        function updateStats() {
+            const stats = computeStats();
+
             // Animate stats on first load
             StatsAnimator.animateStats({
-                owned: { el: document.getElementById('owned-count'), value: ownedMain },
-                total: { el: document.getElementById('total-count'), value: mainCards.length },
-                totalValue: { el: document.getElementById('total-value'), value: Math.round(totalValue) },
-                ownedValue: { el: document.getElementById('owned-value'), value: Math.round(ownedValue) },
-                neededValue: { el: document.getElementById('needed-value'), value: Math.round(neededValue) }
+                owned: { el: document.getElementById('owned-count'), value: stats.owned },
+                total: { el: document.getElementById('total-count'), value: stats.total },
+                totalValue: { el: document.getElementById('total-value'), value: stats.ownedValue + stats.neededValue },
+                ownedValue: { el: document.getElementById('owned-value'), value: stats.ownedValue },
+                neededValue: { el: document.getElementById('needed-value'), value: stats.neededValue }
             });
-
-            // Save stats for index page to read (gist is source of truth)
-            if (window.githubSync && githubSync.isLoggedIn()) {
-                githubSync.saveChecklistStats('jmu-pro-players', {
-                    owned: ownedMain,
-                    total: mainCards.length,
-                    ownedValue: Math.round(ownedValue),
-                    neededValue: Math.round(neededValue),
-                    extrasOwned: ownedAlternates,
-                    extrasTotal: alternates.length
-                });
-            }
+            // Stats are now saved atomically with owned cards via getStats callback
         }
 
 

--- a/shared.js
+++ b/shared.js
@@ -28,6 +28,7 @@ class ChecklistManager {
         this.ownedCards = [];
         this.isReadOnly = true;
         this.onOwnedChange = config.onOwnedChange || (() => {});
+        this.getStats = config.getStats || null; // Optional: return stats object for combined save
     }
 
     // Generate unique card ID from card data
@@ -103,7 +104,9 @@ class ChecklistManager {
         // Sync to GitHub if logged in
         if (window.githubSync && githubSync.isLoggedIn()) {
             this.setSyncStatus('syncing', 'Syncing...');
-            const success = await githubSync.saveChecklist(this.checklistId, this.ownedCards);
+            // Get stats if callback provided (saves both atomically to avoid race condition)
+            const stats = this.getStats ? this.getStats() : null;
+            const success = await githubSync.saveChecklist(this.checklistId, this.ownedCards, stats);
             if (success) {
                 this.setSyncStatus('synced', 'Synced');
             } else {

--- a/washington-qbs-rookie-checklist.html
+++ b/washington-qbs-rookie-checklist.html
@@ -450,7 +450,8 @@
             checklistId: 'washington-qbs',
             ownerUsername: 'iammike',
             localStorageKey: 'washington-qbs-owned',
-            onOwnedChange: () => { render(); }
+            onOwnedChange: () => { render(); },
+            getStats: () => computeStats()
         });
 
         // Wrapper functions for backward compatibility
@@ -694,6 +695,29 @@
             updateStats(filtered);
         }
 
+        // Compute stats for saving (always uses all QBs, not filtered)
+        function computeStats() {
+            const countableQbs = qbs.filter(qb => !qb.collectionLink);
+            let ownedCount = 0, totalValue = 0, ownedValue = 0, neededValue = 0;
+            countableQbs.forEach(qb => {
+                const price = qb.price || 0;
+                const owned = isOwned(getCardId(qb));
+                totalValue += price;
+                if (owned) {
+                    ownedCount++;
+                    ownedValue += price;
+                } else {
+                    neededValue += price;
+                }
+            });
+            return {
+                owned: ownedCount,
+                total: countableQbs.length,
+                ownedValue: Math.round(ownedValue),
+                neededValue: Math.round(neededValue)
+            };
+        }
+
         function updateStats(filteredQbs) {
             // Use filtered list if provided, otherwise use all
             const visibleQbs = filteredQbs || qbs;
@@ -721,16 +745,7 @@
                 ownedValue: { el: document.getElementById('owned-value'), value: Math.round(ownedValue) },
                 neededValue: { el: document.getElementById('needed-value'), value: Math.round(neededValue) }
             });
-
-            // Save stats for index page to read (gist is source of truth)
-            if (window.githubSync && githubSync.isLoggedIn()) {
-                githubSync.saveChecklistStats('washington-qbs', {
-                    owned: ownedCount,
-                    total: totalCount,
-                    ownedValue: Math.round(ownedValue),
-                    neededValue: Math.round(neededValue)
-                });
-            }
+            // Stats are now saved atomically with owned cards via getStats callback
         }
 
         document.getElementById('sort-filter').addEventListener('change', render);


### PR DESCRIPTION
## Summary

### Race condition fix (#74)
- Add `getStats` callback to ChecklistManager config
- When saving owned cards, also save stats in the same API call
- Remove separate `saveChecklistStats()` calls that could race with owned card saves

### Multi-tab cache fix (#75)  
- Clear cache when tab becomes visible again via `visibilitychange` event
- Ensures fresh data is fetched if changes were made in another tab

## Test plan
- [ ] Toggle a card owned, verify stats still update correctly
- [ ] Open site in two tabs, toggle cards in one, switch to other tab and verify it shows updated data after refresh
- [ ] Check index page still shows correct aggregate stats

Closes #74, closes #75