### PR TITLE
Consolidate card rendering logic with shared utilities

### DIFF
--- a/jayden-daniels-rookie-checklist.html
+++ b/jayden-daniels-rookie-checklist.html
@@ -404,28 +404,21 @@
             const cardId = getCardId(card);
             const owned = isOwned(cardId);
             const price = estimatePrice(card);
-            const priceClass = price < 3 ? '' : price < 10 ? 'mid' : 'high';
-            const searchUrl = `https://www.ebay.com/sch/i.html?_nkw=${card.search}&_sop=15&LH_BIN=1`;
-            const scpSearch = `https://www.sportscardspro.com/search-products?q=${card.search.replace(/\+/g, '+')}&type=prices`;
+            const searchUrl = CardRenderer.getEbayUrl(card.search);
+            const scpUrl = CardRenderer.getScpUrl(card.search);
 
             return `
                 <div class="card ${owned ? 'owned' : ''}" data-price="${price}" data-type="${card.type}">
                     <div class="card-image-wrapper">
-                        <span class="price-badge ${priceClass}">$${Math.max(1, Math.round(price))}</span>
-                        ${card.img
-                            ? `<a href="${searchUrl}" target="_blank"><img class="card-image" src="${card.img}" alt="${card.set}" loading="lazy" onerror="this.outerHTML='<a href=\\'${searchUrl}\\' target=\\'_blank\\' class=\\'card-image placeholder\\'>Click to view</a>'"></a>`
-                            : `<a href="${searchUrl}" target="_blank" class="card-image placeholder">Click to view on eBay</a>`
-                        }
+                        ${CardRenderer.renderPriceBadge(price)}
+                        ${CardRenderer.renderCardImage(card.img, card.set, searchUrl)}
                     </div>
                     <div class="card-title">${card.set}</div>
                     <div class="card-number">${card.num} ${card.name}</div>
                     <div class="card-type">${card.type}</div>
                     <div class="card-actions${checklistManager.isReadOnly && !owned ? ' links-only' : ''}">
-                        ${!checklistManager.isReadOnly ? `<div class="checkbox-wrapper">
-                            <input type="checkbox" id="${cardId}" ${owned ? 'checked' : ''} onchange="toggleOwned('${cardId}', this)">
-                            <label for="${cardId}">Owned</label>
-                        </div>` : (owned ? '<span class="owned-badge">✓ Owned</span>' : '')}
-                        <span class="search-links"><a href="${searchUrl}" target="_blank" class="search-link">eBay</a> · <a href="${scpSearch}" target="_blank" class="search-link">Prices</a></span>
+                        ${CardRenderer.renderOwnedControl(cardId, owned, checklistManager.isReadOnly)}
+                        ${CardRenderer.renderSearchLinks(searchUrl, scpUrl)}
                     </div>
                 </div>
             `;

--- a/jmu-pro-players-checklist.html
+++ b/jmu-pro-players-checklist.html
@@ -1020,39 +1020,29 @@
         }
 
 
-        function getAchievementHtml(badges) {
-            if (!badges || badges.length === 0) return '';
-            const text = badges.join(', ');
-            return `<span class="achievement">${text}</span>`;
-        }
+        // JMU uses higher price thresholds
+        const jmuPriceThresholds = { mid: 5, high: 15 };
 
         function createCardElement(card) {
             const cardId = getCardId(card);
             const owned = isOwned(cardId);
             const price = card.price;
-            const priceClass = price < 5 ? '' : price < 15 ? 'mid' : 'high';
-            const searchUrl = `https://www.ebay.com/sch/i.html?_nkw=${card.search}&_sop=15&LH_BIN=1`;
+            const searchUrl = CardRenderer.getEbayUrl(card.search);
 
             return `
                 <div class="card ${owned ? 'owned' : ''}" data-price="${price}" data-sport="${card.sport}">
                     <div class="card-image-wrapper">
-                        <span class="price-badge ${priceClass}">$${Math.round(price)}</span>
-                        ${card.img
-                            ? `<a href="${searchUrl}" target="_blank"><img class="card-image" src="${card.img}" alt="${card.set}" loading="lazy" onerror="this.outerHTML='<a href=\\'${searchUrl}\\' target=\\'_blank\\' class=\\'card-image placeholder\\'>Click to view</a>'"></a>`
-                            : `<a href="${searchUrl}" target="_blank" class="card-image placeholder">Click to view on eBay</a>`
-                        }
+                        ${CardRenderer.renderPriceBadge(price, jmuPriceThresholds)}
+                        ${CardRenderer.renderCardImage(card.img, card.set, searchUrl)}
                     </div>
                     <div class="player-name">${card.player}</div>
                     <div class="card-title">${card.set}</div>
                     <div class="card-number">${card.num} ${card.name}</div>
                     <div class="card-type">${card.type}</div>
-                    ${getAchievementHtml(card.badges)}
+                    ${CardRenderer.renderAchievements(card.badges)}
                     <div class="card-actions${checklistManager.isReadOnly && !owned ? ' links-only' : ''}">
-                        ${!checklistManager.isReadOnly ? `<div class="checkbox-wrapper">
-                            <input type="checkbox" id="${cardId}" ${owned ? 'checked' : ''} onchange="toggleOwned('${cardId}', this)">
-                            <label for="${cardId}">Owned</label>
-                        </div>` : (owned ? '<span class="owned-badge">✓ Owned</span>' : '')}
-                        <a href="${searchUrl}" target="_blank" class="search-link">eBay</a>
+                        ${CardRenderer.renderOwnedControl(cardId, owned, checklistManager.isReadOnly)}
+                        ${CardRenderer.renderSearchLinks(searchUrl)}
                     </div>
                 </div>
             `;

--- a/shared.js
+++ b/shared.js
@@ -351,6 +351,9 @@ const FilterUtils = {
  * Card rendering utilities
  */
 const CardRenderer = {
+    // Default price thresholds for badge styling
+    defaultThresholds: { mid: 3, high: 10 },
+
     // Generate eBay search URL
     getEbayUrl(searchTerm) {
         return `https://www.ebay.com/sch/i.html?_nkw=${searchTerm}&_sop=15&LH_BIN=1`;
@@ -370,6 +373,54 @@ const CardRenderer = {
     // Get set name without year
     getSetName(card) {
         return (card.set || '').replace(/^\d{4}\s*/, '').toLowerCase();
+    },
+
+    // Get price badge CSS class based on thresholds
+    getPriceClass(price, thresholds = this.defaultThresholds) {
+        if (price < thresholds.mid) return '';
+        if (price < thresholds.high) return 'mid';
+        return 'high';
+    },
+
+    // Render price badge HTML
+    renderPriceBadge(price, thresholds = this.defaultThresholds) {
+        const priceClass = this.getPriceClass(price, thresholds);
+        const displayPrice = Math.max(1, Math.round(price));
+        return `<span class="price-badge ${priceClass}">$${displayPrice}</span>`;
+    },
+
+    // Render card image with fallback
+    renderCardImage(imgSrc, alt, searchUrl) {
+        if (imgSrc) {
+            return `<a href="${searchUrl}" target="_blank"><img class="card-image" src="${imgSrc}" alt="${alt}" loading="lazy" onerror="this.outerHTML='<a href=\\'${searchUrl}\\' target=\\'_blank\\' class=\\'card-image placeholder\\'>Click to view</a>'"></a>`;
+        }
+        return `<a href="${searchUrl}" target="_blank" class="card-image placeholder">Click to view on eBay</a>`;
+    },
+
+    // Render owned checkbox or badge based on read-only state
+    renderOwnedControl(cardId, owned, isReadOnly, onchangeFn = 'toggleOwned') {
+        if (!isReadOnly) {
+            return `<div class="checkbox-wrapper">
+                <input type="checkbox" id="${cardId}" ${owned ? 'checked' : ''} onchange="${onchangeFn}('${cardId}', this)">
+                <label for="${cardId}">Owned</label>
+            </div>`;
+        }
+        return owned ? '<span class="owned-badge">✓ Owned</span>' : '';
+    },
+
+    // Render search links (eBay only, or eBay + SCP)
+    renderSearchLinks(searchUrl, scpUrl = null) {
+        if (scpUrl) {
+            return `<span class="search-links"><a href="${searchUrl}" target="_blank" class="search-link">eBay</a> · <a href="${scpUrl}" target="_blank" class="search-link">Prices</a></span>`;
+        }
+        return `<a href="${searchUrl}" target="_blank" class="search-link">eBay</a>`;
+    },
+
+    // Render achievement badges
+    renderAchievements(badges) {
+        if (!badges || badges.length === 0) return '';
+        const text = Array.isArray(badges) ? badges.join(', ') : badges;
+        return `<span class="achievement">${text}</span>`;
     }
 };
 

--- a/washington-qbs-rookie-checklist.html
+++ b/washington-qbs-rookie-checklist.html
@@ -586,7 +586,7 @@
             const cardId = qb.collectionLink ? null : getCardId(qb);
             const cardOwned = cardId ? isOwned(cardId) : false;
 
-            // Special handling for collection link cards
+            // Special handling for collection link cards (Jayden Daniels full checklist)
             if (qb.collectionLink) {
                 const total = jaydenDanielsStats.total || qb.cardCount;
                 const jdBadge = jaydenDanielsStats.owned > 0
@@ -604,17 +604,19 @@
                     <div class="player-name">${qb.name}</div>
                     <div class="player-years">${qb.years} &bull; ${qb.record}</div>
                     ${qb.playoff !== '-' ? `<div class="player-record">Playoffs: ${qb.playoff}</div>` : ''}
-                    ${qb.achievement ? `<span class="achievement">${qb.achievement}</span>` : ''}
+                    ${CardRenderer.renderAchievements(qb.achievement)}
                     <a href="${qb.collectionLink}" class="collection-cta">View Full Collection →</a>
                 </div>`;
             }
 
             const cardClass = `card ${cardOwned ? 'owned' : ''} ${qb.superBowl ? 'super-bowl' : ''}`;
+            const searchUrl = CardRenderer.getEbayUrl(qb.search);
+            const scpUrl = CardRenderer.getScpUrl(encodeURIComponent(qb.name + ' rookie'));
 
             return `<div class="${cardClass}">
                 <div class="card-image-wrapper">
                     ${qb.superBowl ? '<span class="super-bowl-badge">SUPER BOWL</span>' : ''}
-                    <span class="price-badge">$${Math.max(1, Math.round(qb.price))}</span>
+                    ${CardRenderer.renderPriceBadge(qb.price)}
                     <img class="card-image" src="${qb.img}" alt="${qb.name}" loading="lazy" onerror="this.style.display='none'">
                 </div>
                 <div class="player-name">${qb.name}</div>
@@ -623,14 +625,14 @@
                 <div class="card-info">
                     <span class="card-set">${qb.set}</span> ${qb.num}
                 </div>
-                ${qb.achievement ? `<span class="achievement">${qb.achievement}</span>` : ''}
+                ${CardRenderer.renderAchievements(qb.achievement)}
                 <div class="card-actions${checklistManager.isReadOnly && !cardOwned ? ' links-only' : ''}">
                     ${!checklistManager.isReadOnly ? `<label class="checkbox-wrapper">
                         <input type="checkbox" ${cardOwned ? 'checked' : ''} onchange="toggleOwned('${cardId}')">
                         <span>Owned</span>
                     </label>` : (cardOwned ? '<span class="owned-badge">✓ Owned</span>' : '')}
                     <span class="links">
-                        <a href="https://www.ebay.com/sch/i.html?_nkw=${qb.search}&LH_BIN=1&_sop=15" target="_blank">eBay</a> · <a href="https://www.sportscardspro.com/search-products?q=${encodeURIComponent(qb.name + ' rookie')}&type=prices" target="_blank">Prices</a>
+                        <a href="${searchUrl}" target="_blank">eBay</a> · <a href="${scpUrl}" target="_blank">Prices</a>
                     </span>
                 </div>
             </div>`;


### PR DESCRIPTION
## Summary
- Adds CardRenderer utilities to `shared.js` for common card rendering patterns:
  - `renderPriceBadge()` - consistent price badge with configurable thresholds
  - `renderCardImage()` - image with placeholder fallback
  - `renderOwnedControl()` - owned checkbox or badge based on read-only state
  - `renderSearchLinks()` - eBay and optional SCP search links
  - `renderAchievements()` - achievement badge rendering
- Updates all three checklist pages to use these shared utilities
- Preserves page-specific behavior (collection links, super bowl badges)

## Test plan
- [ ] Verify Jayden Daniels checklist renders cards correctly
- [ ] Verify JMU Pro Players checklist renders cards correctly  
- [ ] Verify Washington QBs checklist renders cards correctly
- [ ] Verify owned checkboxes toggle correctly
- [ ] Verify search links open correctly

Closes #80
Closes #65