### PR TITLE
Fix Gold Standard #102 price

### DIFF
--- a/jayden-daniels-rookie-checklist.html
+++ b/jayden-daniels-rookie-checklist.html
@@ -240,7 +240,7 @@
                 { set: "2024 Totally Certified", num: "", name: "Base", type: "Base RC", search: "jayden+daniels+2024+totally+certified+base", img: "jayden-daniels-cards/card_34_5pwAAeSw.webp" },
                 { set: "2024 Zenith", num: "#148", name: "Base", type: "Base RC", search: "jayden+daniels+2024+zenith+148", img: "jayden-daniels-cards/zenith_148.webp" },
                 { set: "2024 Illusions", num: "#93", name: "Base", type: "Base RC", search: "jayden+daniels+2024+illusions+93", img: "jayden-daniels-cards/illusions_93.webp" },
-                { set: "2024 Gold Standard", num: "#102", name: "Base", type: "Base RC", search: "jayden+daniels+2024+gold+standard+102", img: "jayden-daniels-cards/gold_standard_102.webp" },
+                { set: "2024 Gold Standard", num: "#102", name: "Base", type: "Base RC", price: 175, search: "jayden+daniels+2024+gold+standard+102", img: "jayden-daniels-cards/gold_standard_102.webp" },
                 { set: "2024 Select", num: "#217", name: "Club Level", type: "Base RC", search: "jayden+daniels+2024+select+club+level+217", img: "jayden-daniels-cards/select_club_level_217.webp" },
             ],
             topps: [


### PR DESCRIPTION
## Summary
Update 2024 Gold Standard Jayden Daniels #102 with explicit price of $175 based on actual market data (SportsCardsPro shows ~$173 average ungraded).

Gold Standard is a premium product where even base cards command higher prices than typical releases.

## Test plan
- [ ] Verify price badge shows $175 on the card