### PR TITLE
Move Gold Standard to chase section

### DIFF
--- a/jayden-daniels-rookie-checklist.html
+++ b/jayden-daniels-rookie-checklist.html
@@ -198,7 +198,7 @@
     <!-- CHASE CARDS (expensive/rare) -->
     <div class="section chase-section expanded" id="chase-section">
         <div class="section-header chase" onclick="toggleChaseSection()">Chase Cards (SSP/Case Hits)</div>
-        <div class="chase-note">These are rare, expensive inserts ($50+). Not included in main checklist totals.</div>
+        <div class="chase-note">Rare SSPs and premium product cards ($50+). Not included in main checklist totals.</div>
         <div class="card-grid" id="chase-cards"></div>
     </div>
 
@@ -240,7 +240,6 @@
                 { set: "2024 Totally Certified", num: "", name: "Base", type: "Base RC", search: "jayden+daniels+2024+totally+certified+base", img: "jayden-daniels-cards/card_34_5pwAAeSw.webp" },
                 { set: "2024 Zenith", num: "#148", name: "Base", type: "Base RC", search: "jayden+daniels+2024+zenith+148", img: "jayden-daniels-cards/zenith_148.webp" },
                 { set: "2024 Illusions", num: "#93", name: "Base", type: "Base RC", search: "jayden+daniels+2024+illusions+93", img: "jayden-daniels-cards/illusions_93.webp" },
-                { set: "2024 Gold Standard", num: "#102", name: "Base", type: "Base RC", price: 175, search: "jayden+daniels+2024+gold+standard+102", img: "jayden-daniels-cards/gold_standard_102.webp" },
                 { set: "2024 Select", num: "#217", name: "Club Level", type: "Base RC", search: "jayden+daniels+2024+select+club+level+217", img: "jayden-daniels-cards/select_club_level_217.webp" },
             ],
             topps: [
@@ -314,6 +313,7 @@
                 { set: "2024 Prizm Color Blast", num: "#3", name: "Base", type: "Chase SSP", search: "jayden+daniels+2024+prizm+color+blast+3", img: "jayden-daniels-cards/prizm_color_blast.webp" },
                 { set: "2024 Prizm Draft Picks Color Blast", num: "#CB-5", name: "Base", type: "Chase SSP", search: "jayden+daniels+2024+prizm+draft+picks+color+blast", img: "jayden-daniels-cards/prizm_draft_color_blast.webp" },
                 { set: "2024 Phoenix Color Blast", num: "#CB-JDS", name: "Base", type: "Chase SSP", search: "jayden+daniels+2024+phoenix+color+blast", img: "jayden-daniels-cards/phoenix_color_blast.webp" },
+                { set: "2024 Gold Standard", num: "#102", name: "Base", type: "Chase SSP", price: 175, search: "jayden+daniels+2024+gold+standard+102", img: "jayden-daniels-cards/gold_standard_102.webp" },
             ]
         };
 


### PR DESCRIPTION
## Summary
- Moves 2024 Gold Standard #102 from main Panini section to Chase section
- Updates chase section description from "rare, expensive inserts" to "Rare SSPs and premium product cards" to accurately include premium base cards

## Test plan
- [ ] Verify Gold Standard appears in chase section
- [ ] Verify main checklist count decreased by 1