### PR TITLE
Fix chase card types and add vertical Kaboom

### DIFF
--- a/jayden-daniels-rookie-checklist.html
+++ b/jayden-daniels-rookie-checklist.html
@@ -307,13 +307,14 @@
                 { set: "2024 Signature Class After Image", num: "#AI-7", name: "Base", type: "Insert", search: "jayden+daniels+2024+topps+signature+class+after+image", img: "jayden-daniels-cards/signature_class_after_image.webp" },
             ],
             chase: [
-                { set: "2024 Donruss Downtown", num: "#16", name: "Base", type: "Chase SSP", search: "jayden+daniels+2024+donruss+downtown+16", img: "jayden-daniels-cards/donruss_downtown.webp" },
-                { set: "2024 Donruss Optic Uptowns", num: "#2", name: "Base", type: "Chase SSP", search: "jayden+daniels+2024+donruss+optic+uptowns+2", img: "jayden-daniels-cards/donruss_optic_uptowns.webp" },
-                { set: "2024 Absolute Kaboom", num: "#7", name: "Horizontal", type: "Chase SSP", search: "jayden+daniels+2024+absolute+kaboom+7", img: "jayden-daniels-cards/absolute_kaboom.webp" },
-                { set: "2024 Prizm Color Blast", num: "#3", name: "Base", type: "Chase SSP", search: "jayden+daniels+2024+prizm+color+blast+3", img: "jayden-daniels-cards/prizm_color_blast.webp" },
-                { set: "2024 Prizm Draft Picks Color Blast", num: "#CB-5", name: "Base", type: "Chase SSP", search: "jayden+daniels+2024+prizm+draft+picks+color+blast", img: "jayden-daniels-cards/prizm_draft_color_blast.webp" },
-                { set: "2024 Phoenix Color Blast", num: "#CB-JDS", name: "Base", type: "Chase SSP", search: "jayden+daniels+2024+phoenix+color+blast", img: "jayden-daniels-cards/phoenix_color_blast.webp" },
-                { set: "2024 Gold Standard", num: "#102", name: "Base", type: "Chase SSP", price: 175, search: "jayden+daniels+2024+gold+standard+102", img: "jayden-daniels-cards/gold_standard_102.webp" },
+                { set: "2024 Donruss Downtown", num: "#16", name: "Base", type: "Insert SSP", search: "jayden+daniels+2024+donruss+downtown+16", img: "jayden-daniels-cards/donruss_downtown.webp" },
+                { set: "2024 Donruss Optic Uptowns", num: "#2", name: "Base", type: "Insert SSP", search: "jayden+daniels+2024+donruss+optic+uptowns+2", img: "jayden-daniels-cards/donruss_optic_uptowns.webp" },
+                { set: "2024 Absolute Kaboom", num: "#2", name: "Vertical", type: "Insert SSP", search: "jayden+daniels+2024+absolute+kaboom+vertical+2", img: "" },
+                { set: "2024 Absolute Kaboom", num: "#7", name: "Horizontal", type: "Insert SSP", search: "jayden+daniels+2024+absolute+kaboom+7", img: "jayden-daniels-cards/absolute_kaboom.webp" },
+                { set: "2024 Prizm Color Blast", num: "#3", name: "Base", type: "Insert SSP", search: "jayden+daniels+2024+prizm+color+blast+3", img: "jayden-daniels-cards/prizm_color_blast.webp" },
+                { set: "2024 Prizm Draft Picks Color Blast", num: "#CB-5", name: "Base", type: "Insert SSP", search: "jayden+daniels+2024+prizm+draft+picks+color+blast", img: "jayden-daniels-cards/prizm_draft_color_blast.webp" },
+                { set: "2024 Phoenix Color Blast", num: "#CB-JDS", name: "Base", type: "Insert SSP", search: "jayden+daniels+2024+phoenix+color+blast", img: "jayden-daniels-cards/phoenix_color_blast.webp" },
+                { set: "2024 Gold Standard", num: "#102", name: "Base", type: "Premium Base", price: 175, search: "jayden+daniels+2024+gold+standard+102", img: "jayden-daniels-cards/gold_standard_102.webp" },
             ]
         };
 


### PR DESCRIPTION
## Summary
- Changes "Chase SSP" to "Insert SSP" for Downtown, Uptowns, Kaboom, Color Blasts
- Changes Gold Standard type to "Premium Base" (it's a base card from a premium product, not an insert)
- Adds vertical Kaboom #2 (distinct card from horizontal #7)

## Test plan
- [ ] Verify card types display correctly
- [ ] Verify vertical Kaboom appears in chase section