### PR TITLE
Add card editor modal and add card button

### DIFF
--- a/jayden-daniels-rookie-checklist.html
+++ b/jayden-daniels-rookie-checklist.html
@@ -425,9 +425,91 @@
 
         // Initialize edit mode manager
         const editModeManager = new EditModeManager(checklistManager);
+
+        // Initialize card editor modal
+        const cardTypes = ['Base', 'Base RC', 'Parallel', 'Insert', 'Insert SSP', 'Chase SSP'];
+        const cardEditor = new CardEditorModal({
+            cardTypes,
+            onSave: (cardId, cardData, isNew) => {
+                if (isNew) {
+                    // Add new card to appropriate category
+                    const category = cardData.category || 'other';
+                    delete cardData.category;
+                    // Generate search term if not provided
+                    if (!cardData.ebay) {
+                        cardData.search = `jayden+daniels+${cardData.set.replace(/\s+/g, '+')}+${cardData.num}`;
+                    } else {
+                        cardData.search = cardData.ebay;
+                        delete cardData.ebay;
+                    }
+                    if (cards[category]) {
+                        cards[category].push(cardData);
+                    }
+                    console.log('Added new card:', cardData);
+                } else {
+                    // Update existing card
+                    const card = findCardById(cardId);
+                    if (card) {
+                        Object.assign(card, cardData);
+                        if (cardData.ebay) {
+                            card.search = cardData.ebay;
+                            delete card.ebay;
+                        }
+                        console.log('Updated card:', card);
+                    }
+                }
+                renderCards();
+                editModeManager.updateCardEditControls();
+                // TODO: Save to JSON via GitHub API (issue #123)
+            },
+            onDelete: (cardId) => {
+                // Find and remove card from its category
+                for (const category of Object.keys(cards)) {
+                    const idx = cards[category].findIndex(c => getCardId(c) === cardId);
+                    if (idx !== -1) {
+                        cards[category].splice(idx, 1);
+                        console.log('Deleted card:', cardId);
+                        break;
+                    }
+                }
+                renderCards();
+                editModeManager.updateCardEditControls();
+                // TODO: Save to JSON via GitHub API (issue #123)
+            }
+        });
+
+        // Initialize add card button
+        const addCardBtn = new AddCardButton({
+            onClick: () => {
+                cardEditor.openNew('other');
+            }
+        });
+
+        // Helper to find card by ID
+        function findCardById(cardId) {
+            for (const category of Object.keys(cards)) {
+                const card = cards[category].find(c => getCardId(c) === cardId);
+                if (card) return card;
+            }
+            return null;
+        }
+
+        // Wire up edit mode to show/hide add button and handle card edits
         editModeManager.onEditModeChange = (isEditMode) => {
-            // Re-render to update edit buttons on cards
             editModeManager.updateCardEditControls();
+            if (isEditMode) {
+                addCardBtn.show();
+            } else {
+                addCardBtn.hide();
+            }
+        };
+
+        // Handle card edit click - open editor with card data
+        editModeManager.onCardEditClick = (cardId, cardElement) => {
+            const card = findCardById(cardId);
+            if (card) {
+                cardEditor.open(cardId, card);
+            }
         };
 
         // Initialize
@@ -436,6 +518,8 @@
                 await loadCardData();
                 await checklistManager.init();
                 editModeManager.init();
+                cardEditor.init();
+                addCardBtn.init();
                 renderCards();
             } catch (err) {
                 console.error('Failed to initialize:', err);

--- a/jmu-pro-players-checklist.html
+++ b/jmu-pro-players-checklist.html
@@ -513,8 +513,98 @@
 
         // Initialize edit mode manager
         const editModeManager = new EditModeManager(checklistManager);
+
+        // Initialize card editor modal
+        const cardTypes = ['Base', 'Base RC', 'Parallel', 'Insert'];
+        const cardEditor = new CardEditorModal({
+            cardTypes,
+            onSave: (cardId, cardData, isNew) => {
+                if (isNew) {
+                    // Add new card
+                    const category = cardData.category || 'modern';
+                    delete cardData.category;
+                    const newCard = {
+                        player: cardData.name || 'Unknown Player',
+                        sport: 'Football',
+                        set: cardData.set,
+                        num: cardData.num,
+                        type: cardData.type,
+                        img: cardData.img
+                    };
+                    if (cardData.price !== undefined) newCard.price = cardData.price;
+                    if (!cardData.ebay) {
+                        newCard.search = `${newCard.player.replace(/\s+/g, '+')}+${newCard.set.replace(/\s+/g, '+')}`;
+                    } else {
+                        newCard.search = cardData.ebay;
+                    }
+                    if (cards[category]) {
+                        cards[category].push(newCard);
+                    }
+                    console.log('Added new card:', newCard);
+                } else {
+                    // Update existing card
+                    const card = findCardById(cardId);
+                    if (card) {
+                        card.set = cardData.set;
+                        card.num = cardData.num;
+                        card.type = cardData.type;
+                        if (cardData.price !== undefined) card.price = cardData.price;
+                        if (cardData.img) card.img = cardData.img;
+                        if (cardData.ebay) card.search = cardData.ebay;
+                        console.log('Updated card:', card);
+                    }
+                }
+                renderCards();
+                editModeManager.updateCardEditControls();
+                // TODO: Save to JSON via GitHub API (issue #123)
+            },
+            onDelete: (cardId) => {
+                for (const category of Object.keys(cards)) {
+                    const idx = cards[category].findIndex(c => getCardId(c) === cardId);
+                    if (idx !== -1) {
+                        cards[category].splice(idx, 1);
+                        console.log('Deleted card:', cardId);
+                        break;
+                    }
+                }
+                renderCards();
+                editModeManager.updateCardEditControls();
+                // TODO: Save to JSON via GitHub API (issue #123)
+            }
+        });
+
+        // Initialize add card button
+        const addCardBtn = new AddCardButton({
+            onClick: () => {
+                cardEditor.openNew('modern');
+            }
+        });
+
+        // Helper to find card by ID
+        function findCardById(cardId) {
+            for (const category of Object.keys(cards)) {
+                const card = cards[category].find(c => getCardId(c) === cardId);
+                if (card) return card;
+            }
+            return null;
+        }
+
+        // Wire up edit mode to show/hide add button and handle card edits
         editModeManager.onEditModeChange = (isEditMode) => {
             editModeManager.updateCardEditControls();
+            if (isEditMode) {
+                addCardBtn.show();
+            } else {
+                addCardBtn.hide();
+            }
+        };
+
+        // Handle card edit click - open editor with card data
+        editModeManager.onCardEditClick = (cardId, cardElement) => {
+            const card = findCardById(cardId);
+            if (card) {
+                cardEditor.open(cardId, card);
+            }
         };
 
         async function init() {
@@ -522,6 +612,8 @@
                 await loadCardData();
                 await checklistManager.init();
                 editModeManager.init();
+                cardEditor.init();
+                addCardBtn.init();
                 renderCards();
             } catch (err) {
                 console.error('Failed to initialize:', err);

--- a/shared.css
+++ b/shared.css
@@ -863,3 +863,405 @@ body.edit-mode .card:hover {
     border-color: #667eea;
     box-shadow: 0 0 0 2px rgba(102, 126, 234, 0.2);
 }
+
+/* ============================================
+   Card Editor Modal - Broadcast Style
+   ============================================ */
+
+/* Backdrop with broadcast static effect */
+.card-editor-backdrop {
+    position: fixed;
+    inset: 0;
+    background: rgba(10, 10, 20, 0.92);
+    backdrop-filter: blur(8px);
+    z-index: 10000;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    opacity: 0;
+    visibility: hidden;
+    transition: all 0.3s ease;
+}
+
+.card-editor-backdrop.active {
+    opacity: 1;
+    visibility: visible;
+}
+
+.card-editor-backdrop.active .card-editor-modal {
+    transform: translateY(0) scale(1);
+    opacity: 1;
+}
+
+/* Modal container */
+.card-editor-modal {
+    background: linear-gradient(165deg, #1a1a2e 0%, #12121f 50%, #1a1a2e 100%);
+    border-radius: 8px;
+    width: 90%;
+    max-width: 480px;
+    max-height: 90vh;
+    overflow: hidden;
+    position: relative;
+    box-shadow:
+        0 0 0 1px rgba(255, 255, 255, 0.05),
+        0 25px 80px rgba(0, 0, 0, 0.6),
+        0 0 100px rgba(102, 126, 234, 0.15);
+    transform: translateY(20px) scale(0.95);
+    opacity: 0;
+    transition: all 0.4s cubic-bezier(0.16, 1, 0.3, 1);
+}
+
+/* Glowing top accent bar */
+.card-editor-modal::before {
+    content: '';
+    position: absolute;
+    top: 0;
+    left: 0;
+    right: 0;
+    height: 3px;
+    background: linear-gradient(90deg,
+        transparent 0%,
+        #667eea 20%,
+        #f39c12 50%,
+        #667eea 80%,
+        transparent 100%
+    );
+    box-shadow: 0 0 20px rgba(243, 156, 18, 0.5);
+}
+
+/* Corner accent decorations */
+.card-editor-modal::after {
+    content: '';
+    position: absolute;
+    top: 3px;
+    right: 0;
+    width: 60px;
+    height: 60px;
+    background: linear-gradient(135deg, transparent 50%, rgba(243, 156, 18, 0.1) 50%);
+    pointer-events: none;
+}
+
+/* Header */
+.card-editor-header {
+    padding: 20px 24px 16px;
+    border-bottom: 1px solid rgba(255, 255, 255, 0.06);
+    position: relative;
+}
+
+.card-editor-title {
+    font-family: 'Bebas Neue', sans-serif;
+    font-size: 1.6em;
+    font-weight: 400;
+    letter-spacing: 0.1em;
+    margin: 0;
+    background: linear-gradient(180deg, #e0e0e0 0%, #f39c12 100%);
+    -webkit-background-clip: text;
+    -webkit-text-fill-color: transparent;
+    background-clip: text;
+}
+
+.card-editor-subtitle {
+    font-family: 'Barlow', sans-serif;
+    font-size: 0.75em;
+    font-weight: 500;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    color: #666;
+    margin-top: 4px;
+}
+
+.card-editor-close {
+    position: absolute;
+    top: 16px;
+    right: 16px;
+    width: 32px;
+    height: 32px;
+    border: none;
+    background: rgba(255, 255, 255, 0.05);
+    border-radius: 4px;
+    color: #666;
+    font-size: 18px;
+    cursor: pointer;
+    transition: all 0.2s;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+}
+
+.card-editor-close:hover {
+    background: rgba(244, 67, 54, 0.2);
+    color: #f44336;
+}
+
+/* Form body */
+.card-editor-body {
+    padding: 20px 24px;
+    max-height: 60vh;
+    overflow-y: auto;
+}
+
+.card-editor-body::-webkit-scrollbar {
+    width: 6px;
+}
+
+.card-editor-body::-webkit-scrollbar-track {
+    background: rgba(255, 255, 255, 0.02);
+}
+
+.card-editor-body::-webkit-scrollbar-thumb {
+    background: rgba(102, 126, 234, 0.3);
+    border-radius: 3px;
+}
+
+/* Form grid */
+.card-editor-grid {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 16px;
+}
+
+.card-editor-field {
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+}
+
+.card-editor-field.full-width {
+    grid-column: 1 / -1;
+}
+
+.card-editor-label {
+    font-family: 'Barlow', sans-serif;
+    font-size: 0.7em;
+    font-weight: 600;
+    letter-spacing: 0.12em;
+    text-transform: uppercase;
+    color: #888;
+}
+
+.card-editor-input,
+.card-editor-select {
+    font-family: 'Barlow', sans-serif;
+    font-size: 14px;
+    font-weight: 500;
+    padding: 12px 14px;
+    background: rgba(0, 0, 0, 0.3);
+    border: 1px solid rgba(255, 255, 255, 0.08);
+    border-radius: 4px;
+    color: #e0e0e0;
+    transition: all 0.2s;
+}
+
+.card-editor-input:focus,
+.card-editor-select:focus {
+    outline: none;
+    border-color: rgba(102, 126, 234, 0.5);
+    box-shadow: 0 0 0 3px rgba(102, 126, 234, 0.1);
+    background: rgba(0, 0, 0, 0.4);
+}
+
+.card-editor-input::placeholder {
+    color: #555;
+}
+
+.card-editor-select {
+    cursor: pointer;
+    appearance: none;
+    background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='12' height='12' viewBox='0 0 12 12'%3E%3Cpath fill='%23888' d='M6 8L1 3h10z'/%3E%3C/svg%3E");
+    background-repeat: no-repeat;
+    background-position: right 12px center;
+    padding-right: 36px;
+}
+
+.card-editor-select option {
+    background: #1a1a2e;
+    color: #e0e0e0;
+}
+
+/* Image preview section */
+.card-editor-image-section {
+    margin-top: 8px;
+    padding-top: 16px;
+    border-top: 1px solid rgba(255, 255, 255, 0.06);
+}
+
+.card-editor-image-preview {
+    width: 100%;
+    height: 180px;
+    background: rgba(0, 0, 0, 0.3);
+    border: 1px dashed rgba(255, 255, 255, 0.1);
+    border-radius: 4px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    overflow: hidden;
+    margin-top: 8px;
+}
+
+.card-editor-image-preview img {
+    max-width: 100%;
+    max-height: 100%;
+    object-fit: contain;
+}
+
+.card-editor-image-preview .placeholder {
+    color: #555;
+    font-size: 13px;
+    font-weight: 500;
+}
+
+/* Footer with actions */
+.card-editor-footer {
+    padding: 16px 24px 20px;
+    border-top: 1px solid rgba(255, 255, 255, 0.06);
+    display: flex;
+    gap: 12px;
+    justify-content: flex-end;
+    background: rgba(0, 0, 0, 0.2);
+}
+
+.card-editor-btn {
+    font-family: 'Barlow', sans-serif;
+    font-size: 13px;
+    font-weight: 600;
+    letter-spacing: 0.04em;
+    padding: 12px 24px;
+    border-radius: 4px;
+    border: none;
+    cursor: pointer;
+    transition: all 0.2s;
+}
+
+.card-editor-btn.cancel {
+    background: rgba(255, 255, 255, 0.06);
+    color: #888;
+}
+
+.card-editor-btn.cancel:hover {
+    background: rgba(255, 255, 255, 0.1);
+    color: #aaa;
+}
+
+.card-editor-btn.save {
+    background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+    color: white;
+    box-shadow: 0 4px 15px rgba(102, 126, 234, 0.3);
+}
+
+.card-editor-btn.save:hover {
+    transform: translateY(-1px);
+    box-shadow: 0 6px 20px rgba(102, 126, 234, 0.4);
+}
+
+.card-editor-btn.save:active {
+    transform: translateY(0);
+}
+
+.card-editor-btn.delete {
+    background: rgba(244, 67, 54, 0.15);
+    color: #f44336;
+    margin-right: auto;
+}
+
+.card-editor-btn.delete:hover {
+    background: rgba(244, 67, 54, 0.25);
+}
+
+/* Dirty state indicator */
+.card-editor-modal.dirty .card-editor-title::after {
+    content: ' •';
+    color: #f39c12;
+}
+
+/* Mobile responsive */
+@media (max-width: 500px) {
+    .card-editor-modal {
+        width: 95%;
+        max-height: 95vh;
+    }
+
+    .card-editor-grid {
+        grid-template-columns: 1fr;
+    }
+
+    .card-editor-body {
+        max-height: 55vh;
+    }
+
+    .card-editor-footer {
+        flex-wrap: wrap;
+    }
+
+    .card-editor-btn {
+        flex: 1;
+        min-width: 100px;
+    }
+
+    .card-editor-btn.delete {
+        width: 100%;
+        margin-right: 0;
+        margin-bottom: 8px;
+    }
+}
+
+/* ============================================
+   Add Card Floating Action Button
+   ============================================ */
+.add-card-fab {
+    position: fixed;
+    bottom: 24px;
+    left: 50%;
+    transform: translateX(-50%);
+    background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+    color: white;
+    border: none;
+    padding: 14px 28px;
+    border-radius: 30px;
+    font-family: 'Barlow', sans-serif;
+    font-size: 14px;
+    font-weight: 600;
+    letter-spacing: 0.04em;
+    cursor: pointer;
+    box-shadow:
+        0 4px 20px rgba(102, 126, 234, 0.4),
+        0 0 0 3px rgba(102, 126, 234, 0.1);
+    transition: all 0.3s cubic-bezier(0.16, 1, 0.3, 1);
+    z-index: 100;
+}
+
+.add-card-fab:hover {
+    transform: translateX(-50%) translateY(-2px);
+    box-shadow:
+        0 8px 30px rgba(102, 126, 234, 0.5),
+        0 0 0 4px rgba(102, 126, 234, 0.15);
+}
+
+.add-card-fab:active {
+    transform: translateX(-50%) translateY(0);
+}
+
+/* Pulse animation when edit mode is active */
+body.edit-mode .add-card-fab {
+    animation: fabPulse 2s ease-in-out infinite;
+}
+
+@keyframes fabPulse {
+    0%, 100% {
+        box-shadow:
+            0 4px 20px rgba(102, 126, 234, 0.4),
+            0 0 0 3px rgba(102, 126, 234, 0.1);
+    }
+    50% {
+        box-shadow:
+            0 4px 25px rgba(102, 126, 234, 0.5),
+            0 0 0 6px rgba(102, 126, 234, 0.08);
+    }
+}
+
+@media (max-width: 500px) {
+    .add-card-fab {
+        bottom: 16px;
+        padding: 12px 24px;
+        font-size: 13px;
+    }
+}

--- a/washington-qbs-rookie-checklist.html
+++ b/washington-qbs-rookie-checklist.html
@@ -716,8 +716,88 @@
 
         // Initialize edit mode manager
         const editModeManager = new EditModeManager(checklistManager);
+
+        // Initialize card editor modal
+        const cardTypes = ['Base', 'Base RC', 'Parallel', 'Insert'];
+        const cardEditor = new CardEditorModal({
+            cardTypes,
+            onSave: (cardId, cardData, isNew) => {
+                if (isNew) {
+                    // Add new QB
+                    const newQb = {
+                        name: cardData.name || 'Unknown QB',
+                        years: cardData.years || 'TBD',
+                        record: cardData.record || '0-0',
+                        playoff: '-',
+                        era: cardData.era || 'modern',
+                        set: cardData.set,
+                        num: cardData.num,
+                        price: cardData.price,
+                        img: cardData.img
+                    };
+                    if (!cardData.ebay) {
+                        newQb.search = `${newQb.name.replace(/\s+/g, '+')}+rookie+card`;
+                    } else {
+                        newQb.search = cardData.ebay;
+                    }
+                    qbs.push(newQb);
+                    console.log('Added new QB:', newQb);
+                } else {
+                    // Update existing QB
+                    const qb = findQbById(cardId);
+                    if (qb) {
+                        qb.set = cardData.set;
+                        qb.num = cardData.num;
+                        if (cardData.price !== undefined) qb.price = cardData.price;
+                        if (cardData.img) qb.img = cardData.img;
+                        if (cardData.ebay) qb.search = cardData.ebay;
+                        console.log('Updated QB:', qb);
+                    }
+                }
+                render();
+                editModeManager.updateCardEditControls();
+                // TODO: Save to JSON via GitHub API (issue #123)
+            },
+            onDelete: (cardId) => {
+                const idx = qbs.findIndex(qb => getCardId(qb) === cardId);
+                if (idx !== -1) {
+                    qbs.splice(idx, 1);
+                    console.log('Deleted QB:', cardId);
+                }
+                render();
+                editModeManager.updateCardEditControls();
+                // TODO: Save to JSON via GitHub API (issue #123)
+            }
+        });
+
+        // Initialize add card button
+        const addCardBtn = new AddCardButton({
+            onClick: () => {
+                cardEditor.openNew('modern');
+            }
+        });
+
+        // Helper to find QB by ID
+        function findQbById(cardId) {
+            return qbs.find(qb => getCardId(qb) === cardId);
+        }
+
+        // Wire up edit mode to show/hide add button and handle card edits
         editModeManager.onEditModeChange = (isEditMode) => {
             editModeManager.updateCardEditControls();
+            if (isEditMode) {
+                addCardBtn.show();
+            } else {
+                addCardBtn.hide();
+            }
+        };
+
+        // Handle card edit click - open editor with QB data
+        editModeManager.onCardEditClick = (cardId, cardElement) => {
+            const qb = findQbById(cardId);
+            if (qb) {
+                cardEditor.open(cardId, qb);
+            }
         };
 
         // Initialize
@@ -726,6 +806,8 @@
                 await loadQbData();
                 await checklistManager.init();
                 editModeManager.init();
+                cardEditor.init();
+                addCardBtn.init();
                 await loadJaydenDanielsStats();
                 render();
             } catch (err) {


### PR DESCRIPTION
## Summary
- Adds `CardEditorModal` class for editing card details (set, number, name, type, price, eBay search, image URL)
- Adds `AddCardButton` floating action button that appears in edit mode
- Integrates editor modal into all three checklists (Jayden Daniels, Washington QBs, JMU Pros)
- Broadcast-style dark theme modal with purple/gold accents matching site aesthetic

Closes #120

## Test plan
- [ ] Log in as owner on live site
- [ ] Click Edit button to enter edit mode
- [ ] Verify "Add Card" floating button appears at bottom center
- [ ] Click edit button on any card - modal should open with card data
- [ ] Test form validation (set and card number required)
- [ ] Test image preview when entering URL
- [ ] Test dirty state warning when closing with unsaved changes
- [ ] Test Save and Cancel buttons
- [ ] Test Delete button (requires typing "DELETE" to confirm)