### PR TITLE
Move CARD_TYPES to shared.js as universal constant

### DIFF
--- a/jayden-daniels-rookie-checklist.html
+++ b/jayden-daniels-rookie-checklist.html
@@ -427,9 +427,7 @@
         const editModeManager = new EditModeManager(checklistManager);
 
         // Initialize card editor modal
-        const cardTypes = ['Base', 'Base RC', 'Parallel', 'Insert', 'Insert SSP', 'Chase SSP'];
         const cardEditor = new CardEditorModal({
-            cardTypes,
             onSave: (cardId, cardData, isNew) => {
                 if (isNew) {
                     // Add new card to appropriate category

--- a/jmu-pro-players-checklist.html
+++ b/jmu-pro-players-checklist.html
@@ -515,9 +515,7 @@
         const editModeManager = new EditModeManager(checklistManager);
 
         // Initialize card editor modal
-        const cardTypes = ['Base', 'Base RC', 'Parallel', 'Insert'];
         const cardEditor = new CardEditorModal({
-            cardTypes,
             onSave: (cardId, cardData, isNew) => {
                 if (isNew) {
                     // Add new card

--- a/shared.js
+++ b/shared.js
@@ -1,5 +1,8 @@
 // Sports Card Checklists - Shared JavaScript Utilities
 
+// Standard card types used across all checklists
+const CARD_TYPES = ['Base', 'Base RC', 'Parallel', 'Insert', 'Insert SSP', 'Chase SSP'];
+
 // Sanitization helpers for XSS prevention
 function sanitizeText(text) {
     const div = document.createElement('div');
@@ -615,7 +618,7 @@ class CardEditorModal {
     constructor(options = {}) {
         this.onSave = options.onSave || (() => {});
         this.onDelete = options.onDelete || (() => {});
-        this.cardTypes = options.cardTypes || ['Base', 'Base RC', 'Parallel', 'Insert', 'Insert SSP', 'Chase SSP'];
+        this.cardTypes = options.cardTypes || CARD_TYPES;
         this.currentCard = null;
         this.currentCardId = null;
         this.isDirty = false;
@@ -921,6 +924,7 @@ class AddCardButton {
 }
 
 // Export for use in pages
+window.CARD_TYPES = CARD_TYPES;
 window.ChecklistManager = ChecklistManager;
 window.PriceUtils = PriceUtils;
 window.FilterUtils = FilterUtils;

--- a/washington-qbs-rookie-checklist.html
+++ b/washington-qbs-rookie-checklist.html
@@ -718,9 +718,7 @@
         const editModeManager = new EditModeManager(checklistManager);
 
         // Initialize card editor modal
-        const cardTypes = ['Base', 'Base RC', 'Parallel', 'Insert'];
         const cardEditor = new CardEditorModal({
-            cardTypes,
             onSave: (cardId, cardData, isNew) => {
                 if (isNew) {
                     // Add new QB


### PR DESCRIPTION
## Summary
- Adds `CARD_TYPES` constant to shared.js with standard card types
- CardEditorModal now uses this as default
- Removes duplicate cardTypes definitions from all three checklists

## Test plan
- [ ] Verify card type dropdown in editor modal shows all types