### PR TITLE
Add player name, achievements, and auto checkbox to card editor

### DIFF
--- a/jayden-daniels-rookie-checklist.html
+++ b/jayden-daniels-rookie-checklist.html
@@ -426,8 +426,9 @@
         // Initialize edit mode manager
         const editModeManager = new EditModeManager(checklistManager);
 
-        // Initialize card editor modal
+        // Initialize card editor modal (no player field - all cards are Jayden Daniels)
         const cardEditor = new CardEditorModal({
+            showPlayerField: false,
             onSave: (cardId, cardData, isNew) => {
                 if (isNew) {
                     // Add new card to appropriate category

--- a/shared.css
+++ b/shared.css
@@ -1078,6 +1078,37 @@ body.edit-mode .card:hover {
     color: #e0e0e0;
 }
 
+/* Checkbox styling */
+.card-editor-checkbox {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    padding: 12px 14px;
+    background: rgba(0, 0, 0, 0.3);
+    border: 1px solid rgba(255, 255, 255, 0.08);
+    border-radius: 4px;
+    cursor: pointer;
+    transition: all 0.2s;
+}
+
+.card-editor-checkbox:hover {
+    border-color: rgba(102, 126, 234, 0.3);
+}
+
+.card-editor-checkbox input[type="checkbox"] {
+    width: 18px;
+    height: 18px;
+    cursor: pointer;
+    accent-color: #667eea;
+}
+
+.card-editor-checkbox span {
+    font-family: 'Barlow', sans-serif;
+    font-size: 14px;
+    font-weight: 500;
+    color: #e0e0e0;
+}
+
 /* Image preview section */
 .card-editor-image-section {
     margin-top: 8px;


### PR DESCRIPTION
## Summary
- Adds optional **Player Name** field (can be hidden for player-specific checklists like Jayden Daniels)
- Adds **Achievements** field for comma-separated badges (Pro Bowl, Super Bowl Champion, etc.)
- Adds **Autographed** checkbox as a modifier that can apply to any card type
- Jayden Daniels page configured with `showPlayerField: false`

## Test plan
- [ ] On Jayden Daniels page: verify player name field is hidden
- [ ] On Washington QBs or JMU page: verify player name field appears
- [ ] Test achievements field accepts comma-separated values
- [ ] Test autographed checkbox toggles correctly