### PR TITLE
Add GitHub API integration for saving card data

### DIFF
--- a/jayden-daniels-rookie-checklist.html
+++ b/jayden-daniels-rookie-checklist.html
@@ -426,10 +426,22 @@
         // Initialize edit mode manager
         const editModeManager = new EditModeManager(checklistManager);
 
+        // Save card data to GitHub repo
+        async function saveCardDataToRepo() {
+            checklistData.categories = cards;
+            const success = await githubSync.saveCardData('jayden-daniels', checklistData);
+            if (success) {
+                checklistManager.setSyncStatus('synced', 'Saved');
+            } else {
+                checklistManager.setSyncStatus('error', 'Save failed');
+            }
+            return success;
+        }
+
         // Initialize card editor modal (no player field - all cards are Jayden Daniels)
         const cardEditor = new CardEditorModal({
             showPlayerField: false,
-            onSave: (cardId, cardData, isNew) => {
+            onSave: async (cardId, cardData, isNew) => {
                 if (isNew) {
                     // Add new card to appropriate category
                     const category = cardData.category || 'other';
@@ -459,9 +471,11 @@
                 }
                 renderCards();
                 editModeManager.updateCardEditControls();
-                // TODO: Save to JSON via GitHub API (issue #123)
+                // Save to GitHub repo
+                checklistManager.setSyncStatus('syncing', 'Saving...');
+                await saveCardDataToRepo();
             },
-            onDelete: (cardId) => {
+            onDelete: async (cardId) => {
                 // Find and remove card from its category
                 for (const category of Object.keys(cards)) {
                     const idx = cards[category].findIndex(c => getCardId(c) === cardId);
@@ -473,7 +487,9 @@
                 }
                 renderCards();
                 editModeManager.updateCardEditControls();
-                // TODO: Save to JSON via GitHub API (issue #123)
+                // Save to GitHub repo
+                checklistManager.setSyncStatus('syncing', 'Saving...');
+                await saveCardDataToRepo();
             }
         });
 

--- a/jmu-pro-players-checklist.html
+++ b/jmu-pro-players-checklist.html
@@ -514,15 +514,27 @@
         // Initialize edit mode manager
         const editModeManager = new EditModeManager(checklistManager);
 
+        // Save card data to GitHub repo
+        async function saveCardDataToRepo() {
+            checklistData.categories = cards;
+            const success = await githubSync.saveCardData('jmu-pro-players', checklistData);
+            if (success) {
+                checklistManager.setSyncStatus('synced', 'Saved');
+            } else {
+                checklistManager.setSyncStatus('error', 'Save failed');
+            }
+            return success;
+        }
+
         // Initialize card editor modal
         const cardEditor = new CardEditorModal({
-            onSave: (cardId, cardData, isNew) => {
+            onSave: async (cardId, cardData, isNew) => {
                 if (isNew) {
                     // Add new card
                     const category = cardData.category || 'modern';
                     delete cardData.category;
                     const newCard = {
-                        player: cardData.name || 'Unknown Player',
+                        player: cardData.player || 'Unknown Player',
                         sport: 'Football',
                         set: cardData.set,
                         num: cardData.num,
@@ -543,6 +555,7 @@
                     // Update existing card
                     const card = findCardById(cardId);
                     if (card) {
+                        if (cardData.player) card.player = cardData.player;
                         card.set = cardData.set;
                         card.num = cardData.num;
                         card.type = cardData.type;
@@ -554,9 +567,11 @@
                 }
                 renderCards();
                 editModeManager.updateCardEditControls();
-                // TODO: Save to JSON via GitHub API (issue #123)
+                // Save to GitHub repo
+                checklistManager.setSyncStatus('syncing', 'Saving...');
+                await saveCardDataToRepo();
             },
-            onDelete: (cardId) => {
+            onDelete: async (cardId) => {
                 for (const category of Object.keys(cards)) {
                     const idx = cards[category].findIndex(c => getCardId(c) === cardId);
                     if (idx !== -1) {
@@ -567,7 +582,9 @@
                 }
                 renderCards();
                 editModeManager.updateCardEditControls();
-                // TODO: Save to JSON via GitHub API (issue #123)
+                // Save to GitHub repo
+                checklistManager.setSyncStatus('syncing', 'Saving...');
+                await saveCardDataToRepo();
             }
         });
 

--- a/washington-qbs-rookie-checklist.html
+++ b/washington-qbs-rookie-checklist.html
@@ -717,13 +717,25 @@
         // Initialize edit mode manager
         const editModeManager = new EditModeManager(checklistManager);
 
+        // Save QB data to GitHub repo
+        async function saveQbDataToRepo() {
+            checklistData.qbs = qbs;
+            const success = await githubSync.saveCardData('washington-qbs', checklistData);
+            if (success) {
+                checklistManager.setSyncStatus('synced', 'Saved');
+            } else {
+                checklistManager.setSyncStatus('error', 'Save failed');
+            }
+            return success;
+        }
+
         // Initialize card editor modal
         const cardEditor = new CardEditorModal({
-            onSave: (cardId, cardData, isNew) => {
+            onSave: async (cardId, cardData, isNew) => {
                 if (isNew) {
                     // Add new QB
                     const newQb = {
-                        name: cardData.name || 'Unknown QB',
+                        name: cardData.player || 'Unknown QB',
                         years: cardData.years || 'TBD',
                         record: cardData.record || '0-0',
                         playoff: '-',
@@ -744,6 +756,7 @@
                     // Update existing QB
                     const qb = findQbById(cardId);
                     if (qb) {
+                        if (cardData.player) qb.name = cardData.player;
                         qb.set = cardData.set;
                         qb.num = cardData.num;
                         if (cardData.price !== undefined) qb.price = cardData.price;
@@ -754,9 +767,11 @@
                 }
                 render();
                 editModeManager.updateCardEditControls();
-                // TODO: Save to JSON via GitHub API (issue #123)
+                // Save to GitHub repo
+                checklistManager.setSyncStatus('syncing', 'Saving...');
+                await saveQbDataToRepo();
             },
-            onDelete: (cardId) => {
+            onDelete: async (cardId) => {
                 const idx = qbs.findIndex(qb => getCardId(qb) === cardId);
                 if (idx !== -1) {
                     qbs.splice(idx, 1);
@@ -764,7 +779,9 @@
                 }
                 render();
                 editModeManager.updateCardEditControls();
-                // TODO: Save to JSON via GitHub API (issue #123)
+                // Save to GitHub repo
+                checklistManager.setSyncStatus('syncing', 'Saving...');
+                await saveQbDataToRepo();
             }
         });
 


### PR DESCRIPTION
## Summary
- Expands OAuth scope from `gist` to `gist public_repo` for repo file access
- Adds `getRepoFile()` and `updateRepoFile()` methods to GitHubSync class
- Adds `saveCardData()` helper for updating JSON files in `data/` folder
- Wires up all three checklists to persist changes to the repo

Closes #123

## How it works
1. When you save/delete a card in the editor, the page updates the in-memory data
2. Then calls `githubSync.saveCardData()` which:
   - Gets the current file SHA from GitHub API
   - PUTs the updated JSON content to the repo
3. GitHub Pages automatically rebuilds after the commit

## Test plan
- [ ] Log out and log back in (to get new OAuth scope)
- [ ] Enter edit mode, edit a card, save
- [ ] Verify "Saving..." then "Saved" status appears
- [ ] Refresh page - changes should persist
- [ ] Check GitHub repo - should see new commit with changes