### PR TITLE
Fix JMU card ID generation on index page

### DIFF
--- a/index.html
+++ b/index.html
@@ -516,6 +516,11 @@
         // Generate card ID (must match the checklist pages)
         function getCardId(card) {
             if (card.id) return card.id;
+            // JMU cards include player in the ID
+            if (card.player) {
+                const str = (card.player || '') + (card.set || '') + (card.num || '') + (card.name || '');
+                return btoa(str).replace(/[^a-zA-Z0-9]/g, '');
+            }
             const str = (card.set || '') + (card.num || '') + (card.name || '');
             return btoa(str).replace(/[^a-zA-Z0-9]/g, '');
         }


### PR DESCRIPTION
JMU cards include player name in the ID. The index page wasn't accounting for this, causing owned count to show 0.