### PR TITLE
Remove CORS-blocked headers from GitHub API calls

### DIFF
--- a/github-sync.js
+++ b/github-sync.js
@@ -339,15 +339,11 @@ class GitHubSync {
 
         const { owner, repo } = this.getRepoInfo();
         try {
-            // Add cache-busting to ensure we get the latest SHA
+            // Add timestamp to bust browser cache and get latest SHA
             const response = await fetch(
                 `https://api.github.com/repos/${owner}/${repo}/contents/${path}?t=${Date.now()}`,
                 {
-                    headers: {
-                        'Authorization': `Bearer ${this.token}`,
-                        'Cache-Control': 'no-cache',
-                        'If-None-Match': ''  // Bypass ETag caching
-                    }
+                    headers: { 'Authorization': `Bearer ${this.token}` }
                 }
             );
 


### PR DESCRIPTION
Cache-Control and If-None-Match headers are not allowed by GitHub CORS policy. Keep only the timestamp query param for cache busting.