### PR TITLE
Delete optional card properties when cleared during edit

### DIFF
--- a/jayden-daniels-rookie-checklist.html
+++ b/jayden-daniels-rookie-checklist.html
@@ -478,6 +478,11 @@
                             card.search = cardData.ebay;
                             delete card.ebay;
                         }
+                        // Delete optional properties that were cleared
+                        if (!('price' in cardData)) delete card.price;
+                        if (!('img' in cardData)) delete card.img;
+                        if (!('achievement' in cardData)) delete card.achievement;
+                        if (!('auto' in cardData)) delete card.auto;
                         console.log('Updated card:', card);
                     }
                 }

--- a/jmu-pro-players-checklist.html
+++ b/jmu-pro-players-checklist.html
@@ -570,8 +570,11 @@
                         card.set = cardData.set;
                         card.num = cardData.num;
                         card.type = cardData.type;
-                        if (cardData.price !== undefined) card.price = cardData.price;
-                        if (cardData.img) card.img = cardData.img;
+                        // Handle optional fields - set if present, delete if cleared
+                        if ('price' in cardData) card.price = cardData.price;
+                        else delete card.price;
+                        if ('img' in cardData) card.img = cardData.img;
+                        else delete card.img;
                         if (cardData.ebay) card.search = cardData.ebay;
                         console.log('Updated card:', card);
                     }

--- a/washington-qbs-rookie-checklist.html
+++ b/washington-qbs-rookie-checklist.html
@@ -770,8 +770,11 @@
                         if (cardData.player) qb.name = cardData.player;
                         qb.set = cardData.set;
                         qb.num = cardData.num;
-                        if (cardData.price !== undefined) qb.price = cardData.price;
-                        if (cardData.img) qb.img = cardData.img;
+                        // Handle optional fields - set if present, delete if cleared
+                        if ('price' in cardData) qb.price = cardData.price;
+                        else delete qb.price;
+                        if ('img' in cardData) qb.img = cardData.img;
+                        else delete qb.img;
                         if (cardData.ebay) qb.search = cardData.ebay;
                         console.log('Updated QB:', qb);
                     }


### PR DESCRIPTION
When editing a card and clearing optional fields (price, img, etc.), the old values were persisting. Now properly deletes these properties so auto-estimate kicks in for price.