### PR TITLE
Load card data from public gist for logged-out visitors

### DIFF
--- a/index.html
+++ b/index.html
@@ -511,6 +511,10 @@
                 if (window.githubSync?.isLoggedIn()) {
                     const gistData = await githubSync.loadCardData(checklistId);
                     if (gistData) return gistData;
+                } else {
+                    // Not logged in - try public gist for latest data
+                    const publicData = await githubSync.loadPublicCardData(checklistId);
+                    if (publicData) return publicData;
                 }
                 // Fall back to seed data
                 return fetch(`seed/${checklistId}.json`).then(r => r.json()).catch(() => null);

--- a/jayden-daniels-rookie-checklist.html
+++ b/jayden-daniels-rookie-checklist.html
@@ -222,9 +222,17 @@
                     cards = checklistData.categories;
                     return;
                 }
+            } else {
+                // Not logged in - try public gist for latest data
+                const publicData = await githubSync.loadPublicCardData('jayden-daniels');
+                if (publicData) {
+                    checklistData = publicData;
+                    cards = checklistData.categories;
+                    return;
+                }
             }
 
-            // No gist data - load from seed and save to gist for next time
+            // Fall back to seed data
             const response = await fetch('seed/jayden-daniels.json');
             if (!response.ok) {
                 throw new Error('Failed to load card data');

--- a/jmu-pro-players-checklist.html
+++ b/jmu-pro-players-checklist.html
@@ -283,9 +283,17 @@
                     cards = checklistData.categories;
                     return;
                 }
+            } else {
+                // Not logged in - try public gist for latest data
+                const publicData = await githubSync.loadPublicCardData('jmu-pro-players');
+                if (publicData) {
+                    checklistData = publicData;
+                    cards = checklistData.categories;
+                    return;
+                }
             }
 
-            // No gist data - load from seed and save to gist for next time
+            // Fall back to seed data
             const response = await fetch('seed/jmu-pro-players.json');
             if (!response.ok) {
                 throw new Error('Failed to load card data');

--- a/washington-qbs-rookie-checklist.html
+++ b/washington-qbs-rookie-checklist.html
@@ -403,9 +403,17 @@
                     qbs = checklistData.qbs;
                     return;
                 }
+            } else {
+                // Not logged in - try public gist for latest data
+                const publicData = await githubSync.loadPublicCardData('washington-qbs');
+                if (publicData) {
+                    checklistData = publicData;
+                    qbs = checklistData.qbs;
+                    return;
+                }
             }
 
-            // No gist data - load from seed and save to gist for next time
+            // Fall back to seed data
             const response = await fetch('seed/washington-qbs.json');
             if (!response.ok) {
                 throw new Error('Failed to load QB data');


### PR DESCRIPTION
## Summary
- Logged-out visitors now load card data from the public gist instead of stale seed files
- This ensures everyone sees the latest card data
- Falls back to seed data if gist is unavailable

## Test plan
- [ ] Visit site in incognito/logged-out mode
- [ ] Verify cards load and match gist data
- [ ] Verify logged-in users still load from their own gist