### PR TITLE
Fix QB card click to open eBay search

### DIFF
--- a/washington-qbs-rookie-checklist.html
+++ b/washington-qbs-rookie-checklist.html
@@ -601,7 +601,7 @@
                 <div class="card-image-wrapper">
                     ${qb.superBowl ? '<span class="super-bowl-badge">SUPER BOWL</span>' : ''}
                     ${CardRenderer.renderPriceBadge(qb.price)}
-                    <img class="card-image" src="${qb.img}" alt="${qb.name}" loading="lazy" onerror="this.style.display='none'">
+                    ${CardRenderer.renderCardImage(qb.img, qb.name, searchUrl)}
                 </div>
                 <div class="player-name">${qb.name}</div>
                 <div class="player-years">${qb.years} &bull; ${qb.record}</div>


### PR DESCRIPTION
## Summary
- QB card images now open eBay search when clicked, matching JMU and Jayden Daniels pages
- Uses `CardRenderer.renderCardImage()` for consistency

## Test plan
- [ ] Click a QB card image and verify it opens eBay search