### PR TITLE
Fix QB card editing - add missing checkbox ID

### DIFF
--- a/washington-qbs-rookie-checklist.html
+++ b/washington-qbs-rookie-checklist.html
@@ -612,7 +612,7 @@
                 ${CardRenderer.renderAchievements(qb.achievement)}
                 <div class="card-actions${checklistManager.isReadOnly && !cardOwned ? ' links-only' : ''}">
                     ${!checklistManager.isReadOnly ? `<label class="checkbox-wrapper">
-                        <input type="checkbox" ${cardOwned ? 'checked' : ''} onchange="toggleOwned('${cardId}')">
+                        <input type="checkbox" id="${cardId}" ${cardOwned ? 'checked' : ''} onchange="toggleOwned('${cardId}')">
                         <span>Owned</span>
                     </label>` : (cardOwned ? '<span class="owned-badge">✓ Owned</span>' : '')}
                     <span class="links">


### PR DESCRIPTION
## Summary
- QB card checkboxes were missing the `id` attribute
- Edit mode uses the checkbox ID to identify which card to edit
- Added `id="${cardId}"` to the checkbox

## Test plan
- [ ] Enable edit mode on QBs page
- [ ] Click edit button on a card
- [ ] Verify the editor modal opens with correct data