### PR TITLE
Fix QB editor to show player name in correct field

### DIFF
--- a/washington-qbs-rookie-checklist.html
+++ b/washington-qbs-rookie-checklist.html
@@ -887,7 +887,13 @@
         editModeManager.onCardEditClick = (cardId, cardElement) => {
             const qb = findQbById(cardId);
             if (qb) {
-                cardEditor.open(cardId, qb);
+                // Map QB fields to editor fields (qb.name is the player name)
+                const editorData = {
+                    ...qb,
+                    player: qb.name,  // QB's name field is the player name
+                    name: ''          // QBs don't have a card variant name
+                };
+                cardEditor.open(cardId, editorData);
             }
         };
 


### PR DESCRIPTION
## Summary
- QB data uses `name` for player name, but editor expects `player` field
- Map `qb.name` to `player` when opening editor
- Player name now shows in the "Player" field instead of "Card Name"

## Test plan
- [ ] Edit a QB card
- [ ] Verify player name appears in Player field
- [ ] Save and verify name is preserved