### PR TITLE
Hide card name/variant field on QBs page

### DIFF
--- a/shared.js
+++ b/shared.js
@@ -621,6 +621,7 @@ class CardEditorModal {
         this.cardTypes = options.cardTypes || CARD_TYPES;
         this.categories = options.categories || null; // e.g., ['panini', 'topps', 'inserts', 'chase']
         this.showPlayerField = options.showPlayerField !== false; // default true
+        this.showCardNameField = options.showCardNameField !== false; // default true
         this.currentCard = null;
         this.currentCardId = null;
         this.isDirty = false;
@@ -674,10 +675,10 @@ class CardEditorModal {
                                 <span>Auto</span>
                             </label>
                         </div>
-                        <div class="card-editor-field full-width">
+                        ${this.showCardNameField ? `<div class="card-editor-field full-width">
                             <label class="card-editor-label">Card Name / Variant</label>
                             <input type="text" class="card-editor-input" id="editor-name" placeholder="Silver Prizm /199">
-                        </div>
+                        </div>` : ''}
                         <div class="card-editor-field full-width">
                             <label class="card-editor-label">Achievements</label>
                             <input type="text" class="card-editor-input" id="editor-achievement" placeholder="Pro Bowl, Super Bowl Champion">
@@ -793,7 +794,8 @@ class CardEditorModal {
         }
         // Strip # from card number for editing
         this.backdrop.querySelector('#editor-num').value = (cardData.num || '').replace(/^#/, '');
-        this.backdrop.querySelector('#editor-name').value = cardData.name || '';
+        const nameField = this.backdrop.querySelector('#editor-name');
+        if (nameField) nameField.value = cardData.name || '';
         this.backdrop.querySelector('#editor-type').value = cardData.type || 'Base';
         this.backdrop.querySelector('#editor-auto').checked = cardData.auto || false;
         this.backdrop.querySelector('#editor-achievement').value = Array.isArray(cardData.achievement)
@@ -867,10 +869,11 @@ class CardEditorModal {
             num = '#' + num;
         }
 
+        const nameField = this.backdrop.querySelector('#editor-name');
         const data = {
             set: this.backdrop.querySelector('#editor-set').value.trim(),
             num: num,
-            name: this.backdrop.querySelector('#editor-name').value.trim(),
+            name: nameField ? nameField.value.trim() : '',
             type: this.backdrop.querySelector('#editor-type').value,
             img: this.backdrop.querySelector('#editor-img').value.trim()
         };

--- a/washington-qbs-rookie-checklist.html
+++ b/washington-qbs-rookie-checklist.html
@@ -756,6 +756,7 @@
 
         // Initialize card editor modal
         const cardEditor = new CardEditorModal({
+            showCardNameField: false,  // QBs don't use card name/variant
             onSave: async (cardId, cardData, isNew) => {
                 if (isNew) {
                     // Add new QB


### PR DESCRIPTION
## Summary
- Add `showCardNameField` option to CardEditorModal (default: true)
- Set `showCardNameField: false` on QBs page since they don't use card variants

## Test plan
- [ ] Open QB editor - card name field should be hidden
- [ ] Other pages still show the card name field