### PR TITLE
Align QB data: rename 'name' field to 'player'

### DIFF
--- a/seed/washington-qbs.json
+++ b/seed/washington-qbs.json
@@ -27,7 +27,6 @@
   },
   "qbs": [
     {
-      "name": "Joe Theismann",
       "years": "1982-1985",
       "record": "39-13",
       "playoff": "4-1",
@@ -38,10 +37,10 @@
       "img": "washington-qbs-cards/theismann_1975_topps.webp",
       "search": "joe+theismann+1975+topps+416",
       "achievement": "SB XVII, 1983 MVP",
-      "superBowl": true
+      "superBowl": true,
+      "player": "Joe Theismann"
     },
     {
-      "name": "Doug Williams",
       "years": "1986-1989",
       "record": "5-9",
       "playoff": "4-0",
@@ -52,10 +51,10 @@
       "img": "washington-qbs-cards/williams_1979_topps.webp",
       "search": "doug+williams+1979+topps+48",
       "achievement": "SB XXII MVP",
-      "superBowl": true
+      "superBowl": true,
+      "player": "Doug Williams"
     },
     {
-      "name": "Doug Williams",
       "years": "1986-1989",
       "record": "5-9",
       "playoff": "4-0",
@@ -66,10 +65,10 @@
       "img": "washington-qbs-cards/williams_1984_topps_usfl.webp",
       "search": "doug+williams+1984+topps+usfl+96",
       "achievement": "SB XXII MVP",
-      "superBowl": true
+      "superBowl": true,
+      "player": "Doug Williams"
     },
     {
-      "name": "Jay Schroeder",
       "years": "1986-1987",
       "record": "12-4",
       "playoff": "1-1",
@@ -78,10 +77,10 @@
       "num": "#172",
       "price": 1.79,
       "img": "washington-qbs-cards/schroeder_1986_topps.webp",
-      "search": "jay+schroeder+1986+topps+172"
+      "search": "jay+schroeder+1986+topps+172",
+      "player": "Jay Schroeder"
     },
     {
-      "name": "Ed Rubbert",
       "years": "1987",
       "record": "3-0",
       "playoff": "-",
@@ -91,10 +90,10 @@
       "price": 3,
       "img": "washington-qbs-cards/rubbert_1989_collegiate.webp",
       "search": "ed+rubbert+1989+collegiate+collection+louisville",
-      "achievement": "3-0 in '87 strike"
+      "achievement": "3-0 in '87 strike",
+      "player": "Ed Rubbert"
     },
     {
-      "name": "Mark Rypien",
       "years": "1988-1993",
       "record": "42-24",
       "playoff": "4-2",
@@ -105,10 +104,10 @@
       "img": "washington-qbs-cards/rypien_1989_proset.webp",
       "search": "mark+rypien+1989+pro+set+434",
       "achievement": "SB XXVI MVP",
-      "superBowl": true
+      "superBowl": true,
+      "player": "Mark Rypien"
     },
     {
-      "name": "Mark Rypien",
       "years": "1988-1993",
       "record": "42-24",
       "playoff": "4-2",
@@ -119,10 +118,10 @@
       "img": "washington-qbs-cards/rypien_1989_score.webp",
       "search": "mark+rypien+1989+score+105",
       "achievement": "SB XXVI MVP",
-      "superBowl": true
+      "superBowl": true,
+      "player": "Mark Rypien"
     },
     {
-      "name": "Mark Rypien",
       "years": "1988-1993",
       "record": "42-24",
       "playoff": "4-2",
@@ -133,10 +132,10 @@
       "img": "washington-qbs-cards/rypien_1989_topps.webp",
       "search": "mark+rypien+1989+topps+253",
       "achievement": "SB XXVI MVP",
-      "superBowl": true
+      "superBowl": true,
+      "player": "Mark Rypien"
     },
     {
-      "name": "Cary Conklin",
       "years": "1990-1991",
       "record": "0-2",
       "playoff": "-",
@@ -145,10 +144,10 @@
       "num": "#645",
       "price": 1.34,
       "img": "washington-qbs-cards/conklin_1990_score.webp",
-      "search": "cary+conklin+1990+score+645"
+      "search": "cary+conklin+1990+score+645",
+      "player": "Cary Conklin"
     },
     {
-      "name": "Rich Gannon",
       "years": "1993",
       "record": "1-3",
       "playoff": "-",
@@ -158,10 +157,10 @@
       "price": 1.34,
       "img": "washington-qbs-cards/gannon_1990_proset.webp",
       "search": "rich+gannon+1990+pro+set+568",
-      "achievement": "2002 MVP (OAK)"
+      "achievement": "2002 MVP (OAK)",
+      "player": "Rich Gannon"
     },
     {
-      "name": "Gus Frerotte",
       "years": "1994-1998",
       "record": "19-26-1",
       "playoff": "-",
@@ -170,10 +169,10 @@
       "num": "#4",
       "price": 1.75,
       "img": "washington-qbs-cards/frerotte_1995_bowmans-best.webp",
-      "search": "gus+frerotte+1995+bowmans+best+4"
+      "search": "gus+frerotte+1995+bowmans+best+4",
+      "player": "Gus Frerotte"
     },
     {
-      "name": "Heath Shuler",
       "years": "1994-1996",
       "record": "4-9",
       "playoff": "-",
@@ -183,10 +182,10 @@
       "price": 1.32,
       "img": "washington-qbs-cards/shuler_1994_ultra.webp",
       "search": "heath+shuler+1994+ultra+521",
-      "achievement": "#3 Overall Pick"
+      "achievement": "#3 Overall Pick",
+      "player": "Heath Shuler"
     },
     {
-      "name": "John Friesz",
       "years": "1994",
       "record": "1-3",
       "playoff": "-",
@@ -195,10 +194,10 @@
       "num": "#309",
       "price": 1.54,
       "img": "washington-qbs-cards/friesz_1990_score.webp",
-      "search": "john+friesz+1990+score+309"
+      "search": "john+friesz+1990+score+309",
+      "player": "John Friesz"
     },
     {
-      "name": "Jeff Hostetler",
       "years": "1997",
       "record": "2-1",
       "playoff": "-",
@@ -208,10 +207,10 @@
       "price": 1.74,
       "img": "washington-qbs-cards/hostetler_1990_pro-set.webp",
       "search": "jeff+hostetler+1990+pro+set+596",
-      "achievement": "SB XXV (NYG)"
+      "achievement": "SB XXV (NYG)",
+      "player": "Jeff Hostetler"
     },
     {
-      "name": "Trent Green",
       "years": "1998-1999",
       "record": "6-8",
       "playoff": "-",
@@ -220,10 +219,10 @@
       "num": "#PP3",
       "price": 1.49,
       "img": "washington-qbs-cards/green_1993_proset_power.webp",
-      "search": "trent+green+1993+pro+set+power+update+prospects+pp3"
+      "search": "trent+green+1993+pro+set+power+update+prospects+pp3",
+      "player": "Trent Green"
     },
     {
-      "name": "Brad Johnson",
       "years": "1999-2000",
       "record": "17-10",
       "playoff": "1-1",
@@ -233,10 +232,10 @@
       "price": 3.9,
       "img": "washington-qbs-cards/johnson_1992_wild-card.webp",
       "search": "brad+johnson+1992+wild+card+427",
-      "achievement": "SB XXXVII (TB)"
+      "achievement": "SB XXXVII (TB)",
+      "player": "Brad Johnson"
     },
     {
-      "name": "Jeff George",
       "years": "2000-2001",
       "record": "1-6",
       "playoff": "-",
@@ -246,10 +245,10 @@
       "price": 1.44,
       "img": "washington-qbs-cards/george_1990_action_packed.webp",
       "search": "jeff+george+1990+action+packed+rookie+update+1",
-      "achievement": "#1 Overall Pick"
+      "achievement": "#1 Overall Pick",
+      "player": "Jeff George"
     },
     {
-      "name": "Tony Banks",
       "years": "2001-2002",
       "record": "8-6",
       "playoff": "-",
@@ -258,10 +257,10 @@
       "num": "#176",
       "price": 1.06,
       "img": "washington-qbs-cards/banks_1996_leaf.webp",
-      "search": "tony+banks+1996+leaf+176"
+      "search": "tony+banks+1996+leaf+176",
+      "player": "Tony Banks"
     },
     {
-      "name": "Danny Wuerffel",
       "years": "2002",
       "record": "2-2",
       "playoff": "-",
@@ -271,10 +270,10 @@
       "price": 1.51,
       "img": "washington-qbs-cards/wuerffel_1997_metal_universe.webp",
       "search": "danny+wuerffel+1997+metal+universe+198",
-      "achievement": "1996 Heisman"
+      "achievement": "1996 Heisman",
+      "player": "Danny Wuerffel"
     },
     {
-      "name": "Patrick Ramsey",
       "years": "2002-2005",
       "record": "10-14",
       "playoff": "-",
@@ -283,10 +282,10 @@
       "num": "#150",
       "price": 1.49,
       "img": "washington-qbs-cards/ramsey_2002_bowman.webp",
-      "search": "patrick+ramsey+2002+bowman+150"
+      "search": "patrick+ramsey+2002+bowman+150",
+      "player": "Patrick Ramsey"
     },
     {
-      "name": "Shane Matthews",
       "years": "2002",
       "record": "3-4",
       "playoff": "-",
@@ -295,10 +294,10 @@
       "num": "#39",
       "price": 0.99,
       "img": "washington-qbs-cards/matthews_1999_leaf_rookies_stars.webp",
-      "search": "shane+matthews+1999+leaf+rookies+stars+39"
+      "search": "shane+matthews+1999+leaf+rookies+stars+39",
+      "player": "Shane Matthews"
     },
     {
-      "name": "Tim Hasselbeck",
       "years": "2003-2004",
       "record": "1-4",
       "playoff": "-",
@@ -307,10 +306,10 @@
       "num": "#367",
       "price": 1.77,
       "img": "washington-qbs-cards/hasselbeck_2001_topps.webp",
-      "search": "tim+hasselbeck+2001+topps+367"
+      "search": "tim+hasselbeck+2001+topps+367",
+      "player": "Tim Hasselbeck"
     },
     {
-      "name": "Mark Brunell",
       "years": "2004-2006",
       "record": "15-18",
       "playoff": "1-1",
@@ -319,10 +318,10 @@
       "num": "#PP4",
       "price": 1.5,
       "img": "washington-qbs-cards/brunell_1993_proset_power.webp",
-      "search": "mark+brunell+1993+pro+set+power+update+prospects+pp4"
+      "search": "mark+brunell+1993+pro+set+power+update+prospects+pp4",
+      "player": "Mark Brunell"
     },
     {
-      "name": "Smith/Campbell",
       "years": "2005",
       "record": "-",
       "playoff": "-",
@@ -332,10 +331,10 @@
       "price": 2.75,
       "img": "washington-qbs-cards/smith_campbell_2005_leaf_jersey.webp",
       "search": "alex+smith+jason+campbell+2005+leaf+rookies+stars+jersey+280",
-      "achievement": "Dual Jersey /500"
+      "achievement": "Dual Jersey /500",
+      "player": "Smith/Campbell"
     },
     {
-      "name": "Jason Campbell",
       "years": "2006-2009",
       "record": "20-32",
       "playoff": "-",
@@ -344,10 +343,10 @@
       "num": "#5",
       "price": 2.26,
       "img": "washington-qbs-cards/campbell_2005_absolute_jersey.webp",
-      "search": "jason+campbell+2005+playoff+absolute+memorabilia+rookie+jerseys+5"
+      "search": "jason+campbell+2005+playoff+absolute+memorabilia+rookie+jerseys+5",
+      "player": "Jason Campbell"
     },
     {
-      "name": "Todd Collins",
       "years": "2007",
       "record": "3-0",
       "playoff": "0-1",
@@ -356,10 +355,10 @@
       "num": "#24",
       "price": 0.9,
       "img": "washington-qbs-cards/collins_1995_upper_deck.webp",
-      "search": "todd+collins+1995+upper+deck+24"
+      "search": "todd+collins+1995+upper+deck+24",
+      "player": "Todd Collins"
     },
     {
-      "name": "Donovan McNabb",
       "years": "2010",
       "record": "5-8",
       "playoff": "-",
@@ -369,10 +368,10 @@
       "price": 1.54,
       "img": "washington-qbs-cards/mcnabb_1999_press_pass.webp",
       "search": "donovan+mcnabb+1999+press+pass+5",
-      "achievement": "6x Pro Bowl"
+      "achievement": "6x Pro Bowl",
+      "player": "Donovan McNabb"
     },
     {
-      "name": "Rex Grossman",
       "years": "2010-2011",
       "record": "6-10",
       "playoff": "-",
@@ -382,10 +381,10 @@
       "price": 1.49,
       "img": "washington-qbs-cards/grossman_2003_ud_rookie_premiere.webp",
       "search": "rex+grossman+2003+upper+deck+rookie+premiere+rp-4",
-      "achievement": "SB XLI (CHI)"
+      "achievement": "SB XLI (CHI)",
+      "player": "Rex Grossman"
     },
     {
-      "name": "John Beck",
       "years": "2011",
       "record": "0-3",
       "playoff": "-",
@@ -394,10 +393,10 @@
       "num": "#RP-JB",
       "price": 1.5,
       "img": "washington-qbs-cards/beck_2007_ud_rookie_premiere.webp",
-      "search": "john+beck+2007+upper+deck+rookie+premiere"
+      "search": "john+beck+2007+upper+deck+rookie+premiere",
+      "player": "John Beck"
     },
     {
-      "name": "Kirk Cousins",
       "years": "2012-2017",
       "record": "26-30-1",
       "playoff": "0-1",
@@ -407,10 +406,10 @@
       "price": 5.99,
       "img": "washington-qbs-cards/cousins_2012_prizm_auto.webp",
       "search": "kirk+cousins+2012+panini+prizm+rookie+autograph+277",
-      "achievement": "4x Pro Bowl"
+      "achievement": "4x Pro Bowl",
+      "player": "Kirk Cousins"
     },
     {
-      "name": "Robert Griffin III",
       "years": "2012-2015",
       "record": "14-21",
       "playoff": "0-1",
@@ -420,10 +419,10 @@
       "price": 12.83,
       "img": "washington-qbs-cards/rg3_2012_rookies_stars_auto_jersey.webp",
       "search": "robert+griffin+iii+2012+panini+rookies+stars+autograph+jersey+217",
-      "achievement": "2012 OROY"
+      "achievement": "2012 OROY",
+      "player": "Robert Griffin III"
     },
     {
-      "name": "Colt McCoy",
       "years": "2014-2019",
       "record": "1-6",
       "playoff": "-",
@@ -432,10 +431,10 @@
       "num": "#19",
       "price": 1.5,
       "img": "washington-qbs-cards/mccoy_2010_donruss.webp",
-      "search": "colt+mccoy+2010+donruss+rated+rookies+19"
+      "search": "colt+mccoy+2010+donruss+rated+rookies+19",
+      "player": "Colt McCoy"
     },
     {
-      "name": "Alex Smith",
       "years": "2018-2020",
       "record": "11-5",
       "playoff": "-",
@@ -445,10 +444,10 @@
       "price": 0.99,
       "img": "washington-qbs-cards/smith_2005_ud_rookie_prospects.webp",
       "search": "alex+smith+2005+upper+deck+rookie+prospects+rp-as",
-      "achievement": "2020 CPOY"
+      "achievement": "2020 CPOY",
+      "player": "Alex Smith"
     },
     {
-      "name": "Case Keenum",
       "years": "2019",
       "record": "1-7",
       "playoff": "-",
@@ -457,10 +456,10 @@
       "num": "#159",
       "price": 1.03,
       "img": "washington-qbs-cards/keenum_2012_panini-rookies-stars.webp",
-      "search": "case+keenum+2012+panini+rookies+stars+159"
+      "search": "case+keenum+2012+panini+rookies+stars+159",
+      "player": "Case Keenum"
     },
     {
-      "name": "Dwayne Haskins",
       "years": "2019-2020",
       "record": "3-10",
       "playoff": "-",
@@ -470,10 +469,10 @@
       "price": 9.7,
       "img": "washington-qbs-cards/haskins_2019_optic_auto.webp",
       "search": "dwayne+haskins+2019+donruss+optic+rated+rookie+autographs+151",
-      "achievement": "1st Rd Pick, RIP"
+      "achievement": "1st Rd Pick, RIP",
+      "player": "Dwayne Haskins"
     },
     {
-      "name": "Taylor Heinicke",
       "years": "2020-2022",
       "record": "12-11-1",
       "playoff": "0-1",
@@ -482,10 +481,10 @@
       "num": "#288",
       "price": 1.89,
       "img": "washington-qbs-cards/heinicke_2015_prizm.webp",
-      "search": "taylor+heinicke+2015+prizm+288"
+      "search": "taylor+heinicke+2015+prizm+288",
+      "player": "Taylor Heinicke"
     },
     {
-      "name": "Ryan Fitzpatrick",
       "years": "2021",
       "record": "0-1",
       "playoff": "-",
@@ -495,10 +494,10 @@
       "price": 3.04,
       "img": "washington-qbs-cards/fitzpatrick_2005_ud_reflections.webp",
       "search": "ryan+fitzpatrick+2005+upper+deck+reflections+182",
-      "achievement": "17-year career"
+      "achievement": "17-year career",
+      "player": "Ryan Fitzpatrick"
     },
     {
-      "name": "Carson Wentz",
       "years": "2022",
       "record": "2-5",
       "playoff": "-",
@@ -508,10 +507,10 @@
       "price": 1.99,
       "img": "washington-qbs-cards/wentz_2016_donruss_optic.webp",
       "search": "carson+wentz+2016+donruss+optic+156",
-      "achievement": "#2 Overall Pick"
+      "achievement": "#2 Overall Pick",
+      "player": "Carson Wentz"
     },
     {
-      "name": "Sam Howell",
       "years": "2022-2023",
       "record": "5-13",
       "playoff": "-",
@@ -520,20 +519,20 @@
       "num": "#PJ-SH",
       "price": 2.17,
       "img": "washington-qbs-cards/howell_2022_prizm_jersey.webp",
-      "search": "sam+howell+2022+panini+prizm+premier+jerseys+pj-sh"
+      "search": "sam+howell+2022+panini+prizm+premier+jerseys+pj-sh",
+      "player": "Sam Howell"
     },
     {
-      "name": "Jayden Daniels",
       "years": "2024-2025",
       "record": "14-10",
       "playoff": "2-1",
       "era": "modern",
       "collectionLink": "jayden-daniels-rookie-checklist.html",
       "cardCount": 40,
-      "achievement": "2024 OROY"
+      "achievement": "2024 OROY",
+      "player": "Jayden Daniels"
     },
     {
-      "name": "Josh Johnson",
       "years": "2025",
       "record": "1-1",
       "playoff": "-",
@@ -542,10 +541,10 @@
       "num": "#258",
       "price": 1.01,
       "img": "washington-qbs-cards/johnson_2008_upper_deck.webp",
-      "search": "josh+johnson+2008+upper+deck+258"
+      "search": "josh+johnson+2008+upper+deck+258",
+      "player": "Josh Johnson"
     },
     {
-      "name": "Marcus Mariota",
       "years": "2025",
       "record": "2-6",
       "playoff": "-",
@@ -555,7 +554,8 @@
       "price": 2.91,
       "img": "washington-qbs-cards/mariota_2015_finest_die_cut.webp",
       "search": "marcus+mariota+2015+topps+finest+atomic+rookie+die+cut",
-      "achievement": "#2 Overall Pick"
+      "achievement": "#2 Overall Pick",
+      "player": "Marcus Mariota"
     }
   ],
   "meta": {

--- a/washington-qbs-rookie-checklist.html
+++ b/washington-qbs-rookie-checklist.html
@@ -440,7 +440,7 @@
 
         // Wrapper functions for backward compatibility
         function getCardId(qb) {
-            return btoa(qb.name + qb.set + qb.num).replace(/[^a-zA-Z0-9]/g, '');
+            return btoa(qb.player + qb.set + qb.num).replace(/[^a-zA-Z0-9]/g, '');
         }
 
         function isOwned(cardId) {
@@ -585,7 +585,7 @@
                             <img src="jayden-daniels-cards/resurgence_196.webp" alt="" loading="lazy">
                         </div>
                     </div>
-                    <div class="player-name">${qb.name}</div>
+                    <div class="player-name">${qb.player}</div>
                     <div class="player-years">${qb.years} &bull; ${qb.record}</div>
                     ${qb.playoff !== '-' ? `<div class="player-record">Playoffs: ${qb.playoff}</div>` : ''}
                     ${CardRenderer.renderAchievements(qb.achievement)}
@@ -595,15 +595,15 @@
 
             const cardClass = `card ${cardOwned ? 'owned' : ''} ${qb.superBowl ? 'super-bowl' : ''}`;
             const searchUrl = CardRenderer.getEbayUrl(qb.search);
-            const scpUrl = CardRenderer.getScpUrl(encodeURIComponent(qb.name + ' rookie'));
+            const scpUrl = CardRenderer.getScpUrl(encodeURIComponent(qb.player + ' rookie'));
 
             return `<div class="${cardClass}">
                 <div class="card-image-wrapper">
                     ${qb.superBowl ? '<span class="super-bowl-badge">SUPER BOWL</span>' : ''}
                     ${CardRenderer.renderPriceBadge(qb.price)}
-                    ${CardRenderer.renderCardImage(qb.img, qb.name, searchUrl)}
+                    ${CardRenderer.renderCardImage(qb.img, qb.player, searchUrl)}
                 </div>
-                <div class="player-name">${qb.name}</div>
+                <div class="player-name">${qb.player}</div>
                 <div class="player-years">${qb.years} &bull; ${qb.record}</div>
                 ${qb.playoff !== '-' ? `<div class="player-record">Playoffs: ${qb.playoff}</div>` : ''}
                 <div class="card-info">
@@ -633,7 +633,7 @@
                 const cardId = qb.collectionLink ? null : getCardId(qb);
                 if (statusFilter === 'owned' && (!cardId || !isOwned(cardId))) return false;
                 if (statusFilter === 'needed' && cardId && isOwned(cardId)) return false;
-                if (searchTerm && !qb.name.toLowerCase().includes(searchTerm)) return false;
+                if (searchTerm && !qb.player.toLowerCase().includes(searchTerm)) return false;
                 return true;
             });
 
@@ -761,7 +761,7 @@
                 if (isNew) {
                     // Add new QB
                     const newQb = {
-                        name: cardData.player || 'Unknown QB',
+                        player: cardData.player || 'Unknown QB',
                         years: cardData.years || 'TBD',
                         record: cardData.record || '0-0',
                         playoff: '-',
@@ -772,7 +772,7 @@
                         img: cardData.img
                     };
                     if (!cardData.ebay) {
-                        newQb.search = `${newQb.name.replace(/\s+/g, '+')}+rookie+card`;
+                        newQb.search = `${newQb.player.replace(/\s+/g, '+')}+rookie+card`;
                     } else {
                         newQb.search = cardData.ebay;
                     }
@@ -783,7 +783,7 @@
                     const found = findQbWithIndex(cardId);
                     if (found) {
                         const { qb, index } = found;
-                        if (cardData.player) qb.name = cardData.player;
+                        if (cardData.player) qb.player = cardData.player;
                         qb.set = cardData.set;
                         qb.num = cardData.num;
                         // Handle optional fields - set if present, delete if cleared
@@ -856,8 +856,8 @@
                 if (startB > startA) return true;
                 if (startB < startA) return false;
                 // Same QB era - sort by player name
-                if (q.name > qb.name) return true;
-                if (q.name < qb.name) return false;
+                if (q.player > qb.player) return true;
+                if (q.player < qb.player) return false;
                 // Same player - sort by card year
                 const setYearA = getSetYear(qb.set);
                 const setYearB = getSetYear(q.set);
@@ -888,13 +888,7 @@
         editModeManager.onCardEditClick = (cardId, cardElement) => {
             const qb = findQbById(cardId);
             if (qb) {
-                // Map QB fields to editor fields (qb.name is the player name)
-                const editorData = {
-                    ...qb,
-                    player: qb.name,  // QB's name field is the player name
-                    name: ''          // QBs don't have a card variant name
-                };
-                cardEditor.open(cardId, editorData);
+                cardEditor.open(cardId, qb);
             }
         };
 


### PR DESCRIPTION
## Summary
- Rename `name` field to `player` in QB data for consistency with JMU checklist
- Update all code references from `qb.name` to `qb.player`
- Simplify editor mapping (no longer needed)
- Update both gist and seed data

All three checklists now use consistent field names:
- `player` for player name
- `name` for card variant (JD, JMU only)

## Test plan
- [ ] QBs page loads correctly
- [ ] QB cards display player names
- [ ] Edit mode shows player name in correct field
- [ ] Save/edit works correctly