### PR TITLE
Fix card category change not moving card

### DIFF
--- a/jayden-daniels-rookie-checklist.html
+++ b/jayden-daniels-rookie-checklist.html
@@ -487,7 +487,9 @@
                     // Update existing card
                     const found = findCardWithCategory(cardId);
                     if (found) {
-                        const { card, category, index } = found;
+                        const { card, category: oldCategory, index } = found;
+                        const newCategory = cardData.category || oldCategory;
+                        delete cardData.category;
                         Object.assign(card, cardData);
                         if (cardData.ebay) {
                             card.search = cardData.ebay;
@@ -498,10 +500,11 @@
                         if (!('img' in cardData)) delete card.img;
                         if (!('achievement' in cardData)) delete card.achievement;
                         if (!('auto' in cardData)) delete card.auto;
-                        // Re-sort: remove from current position and re-insert sorted
-                        cards[category].splice(index, 1);
-                        insertCardSorted(cards[category], card);
-                        console.log('Updated card:', card);
+                        // Remove from old category
+                        cards[oldCategory].splice(index, 1);
+                        // Insert into (possibly new) category
+                        insertCardSorted(cards[newCategory], card);
+                        console.log('Updated card:', card, newCategory !== oldCategory ? `(moved to ${newCategory})` : '');
                     }
                 }
                 renderCards();

--- a/jmu-pro-players-checklist.html
+++ b/jmu-pro-players-checklist.html
@@ -580,7 +580,9 @@
                     // Update existing card
                     const found = findCardWithCategory(cardId);
                     if (found) {
-                        const { card, category, index } = found;
+                        const { card, category: oldCategory, index } = found;
+                        const newCategory = cardData.category || oldCategory;
+                        delete cardData.category;
                         if (cardData.player) card.player = cardData.player;
                         card.set = cardData.set;
                         card.num = cardData.num;
@@ -591,10 +593,11 @@
                         if ('img' in cardData) card.img = cardData.img;
                         else delete card.img;
                         if (cardData.ebay) card.search = cardData.ebay;
-                        // Re-sort: remove from current position and re-insert sorted
-                        cards[category].splice(index, 1);
-                        insertCardSorted(cards[category], card);
-                        console.log('Updated card:', card);
+                        // Remove from old category
+                        cards[oldCategory].splice(index, 1);
+                        // Insert into (possibly new) category
+                        insertCardSorted(cards[newCategory], card);
+                        console.log('Updated card:', card, newCategory !== oldCategory ? `(moved to ${newCategory})` : '');
                     }
                 }
                 renderCards();


### PR DESCRIPTION
## Summary
- When editing a card and changing its category, the card now moves to the new category
- Previously it would stay in the old category even after changing the dropdown

## Test plan
- [ ] Edit a card in Jayden Daniels checklist
- [ ] Change category from inserts to chase (or vice versa)
- [ ] Verify card moves to new category
- [ ] Same test on JMU checklist