### PR TITLE
Fix editor showing wrong category when editing cards

### DIFF
--- a/jayden-daniels-rookie-checklist.html
+++ b/jayden-daniels-rookie-checklist.html
@@ -582,9 +582,10 @@
 
         // Handle card edit click - open editor with card data
         editModeManager.onCardEditClick = (cardId, cardElement) => {
-            const card = findCardById(cardId);
-            if (card) {
-                cardEditor.open(cardId, card);
+            const found = findCardWithCategory(cardId);
+            if (found) {
+                // Include category so editor dropdown shows correct value
+                cardEditor.open(cardId, { ...found.card, category: found.category });
             }
         };
 

--- a/jmu-pro-players-checklist.html
+++ b/jmu-pro-players-checklist.html
@@ -687,9 +687,10 @@
 
         // Handle card edit click - open editor with card data
         editModeManager.onCardEditClick = (cardId, cardElement) => {
-            const card = findCardById(cardId);
-            if (card) {
-                cardEditor.open(cardId, card);
+            const found = findCardWithCategory(cardId);
+            if (found) {
+                // Include category so editor dropdown shows correct value
+                cardEditor.open(cardId, { ...found.card, category: found.category });
             }
         };
 


### PR DESCRIPTION
## Summary
- Editor now shows the correct category when editing existing cards
- Previously it would show a stale/default value
- Fixed by passing the card's actual category to the editor

## Test plan
- [ ] Edit a card in the chase section
- [ ] Verify dropdown shows "Chase"
- [ ] Change to inserts, save
- [ ] Edit same card again - should now show "Inserts"