### PR TITLE
Improve mobile nav layout

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -14,6 +14,7 @@
 - For visual/layout changes (CSS, spacing, styling), open the file locally for user review before committing
 - Use `open index.html` or `open <filename>.html` to preview in browser
 - Wait for user approval before creating a PR for layout tweaks
+- **Auth does not work locally** - GitHub OAuth requires the deployed domain, so any auth-related features (edit mode, owned cards, sync) must be tested post-merge on the live site
 
 ## Consistency
 - When making changes to a page or card component, consider applying the same change to all checklists/cards

--- a/shared.css
+++ b/shared.css
@@ -278,8 +278,8 @@ h1 {
     .nav-inner {
         height: auto;
         flex-wrap: wrap;
-        padding: 12px 16px;
-        gap: 12px;
+        padding: 10px 12px;
+        gap: 8px;
     }
 
     .nav-brand-text { display: none; }
@@ -293,11 +293,50 @@ h1 {
         justify-content: center;
         padding-top: 8px;
         border-top: 1px solid rgba(255,255,255,0.05);
+        gap: 2px;
     }
 
     .nav-link {
-        font-size: 0.85em;
-        padding: 6px 12px;
+        font-size: 0.75em;
+        padding: 6px 8px;
+    }
+
+    .nav-auth {
+        gap: 8px;
+    }
+
+    /* Compact edit button - icon only on mobile */
+    .nav-btn.edit-btn {
+        padding: 6px 10px;
+        font-size: 0.9em;
+    }
+
+    /* Hide "Edit"/"Done" text, show only emoji */
+    .nav-btn.edit-btn .btn-text {
+        display: none;
+    }
+
+    /* Compact other nav buttons */
+    .nav-btn {
+        padding: 5px 10px;
+        font-size: 0.75em;
+    }
+
+    /* Hide sync status text on mobile */
+    .sync-status {
+        font-size: 0;
+        min-width: auto;
+    }
+    .sync-status::before {
+        font-size: 12px;
+    }
+    .sync-status.syncing::before { content: '🔄'; }
+    .sync-status.synced::before { content: '✓'; font-size: 14px; }
+    .sync-status.error::before { content: '⚠'; }
+
+    /* Compact user display */
+    .nav-user span {
+        display: none;
     }
 }
 

--- a/shared.js
+++ b/shared.js
@@ -528,7 +528,7 @@ class EditModeManager {
         this.editButton = document.createElement('button');
         this.editButton.id = 'edit-mode-btn';
         this.editButton.className = 'nav-btn edit-btn';
-        this.editButton.innerHTML = '✏️ Edit';
+        this.editButton.innerHTML = '✏️ <span class="btn-text">Edit</span>';
         this.editButton.style.display = 'none';
         this.editButton.onclick = () => this.toggleEditMode();
 
@@ -549,7 +549,7 @@ class EditModeManager {
         this.editButton.style.display = isOwner ? '' : 'none';
 
         // Update button text based on current mode
-        this.editButton.innerHTML = this.isEditMode ? '✓ Done' : '✏️ Edit';
+        this.editButton.innerHTML = this.isEditMode ? '✓ <span class="btn-text">Done</span>' : '✏️ <span class="btn-text">Edit</span>';
         this.editButton.classList.toggle('active', this.isEditMode);
     }
 


### PR DESCRIPTION
## Summary
Fixes #146 - Nav bar cluttered and broken on mobile

- Edit button shows icon only on mobile (hides "Edit"/"Done" text)
- Nav links have smaller font and tighter spacing
- Sync status shows icons (🔄, ✓, ⚠) instead of text on mobile
- User display hides username, shows only avatar
- Reduced padding and gaps throughout

Also adds a rule to CLAUDE.md about auth not working locally.

## Test plan
- [ ] Test on mobile device or responsive mode
- [ ] Verify edit button shows only pencil icon on mobile
- [ ] Verify nav links are readable and not overlapping
- [ ] Verify sync status shows icons