### PR TITLE
Replace auth panel with avatar dropdown menu

### DIFF
--- a/shared.css
+++ b/shared.css
@@ -225,82 +225,154 @@ h1 {
     border-radius: 2px 2px 0 0;
 }
 
-/* Auth section - broadcast control panel aesthetic */
+/* Auth section - avatar with dropdown menu */
 .nav-auth {
     display: flex;
     align-items: center;
-    gap: 0;
-    background: rgba(0, 0, 0, 0.3);
-    border: 1px solid rgba(255, 255, 255, 0.06);
-    border-radius: 4px;
-    padding: 4px;
+    position: relative;
 }
 
 #auth-content {
-    display: flex;
-    align-items: center;
-    gap: 0;
+    position: relative;
 }
 
-/* Divider between auth elements */
-.nav-auth-divider {
-    width: 1px;
-    height: 20px;
-    background: rgba(255, 255, 255, 0.1);
-    margin: 0 2px;
-}
-
-.nav-user {
-    display: flex;
-    align-items: center;
-    gap: 8px;
-    color: #777;
-    font-size: 0.75em;
-    font-weight: 500;
-    letter-spacing: 0.05em;
-    text-transform: uppercase;
-    padding: 6px 12px;
-}
-
-.nav-user img {
-    width: 22px;
-    height: 22px;
-    border-radius: 50%;
-    border: 1px solid rgba(255, 255, 255, 0.15);
-}
-
-.nav-btn {
-    font-family: 'Barlow', sans-serif;
-    font-size: 0.7em;
-    font-weight: 600;
-    letter-spacing: 0.06em;
-    text-transform: uppercase;
-    padding: 8px 12px;
-    border-radius: 2px;
+/* Avatar trigger button */
+.nav-avatar-btn {
+    background: none;
     border: none;
+    padding: 4px;
+    cursor: pointer;
+    border-radius: 50%;
+    transition: all 0.15s ease;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+}
+
+.nav-avatar-btn:hover {
+    background: rgba(255, 255, 255, 0.1);
+}
+
+.nav-avatar-btn img {
+    width: 28px;
+    height: 28px;
+    border-radius: 50%;
+    border: 2px solid rgba(255, 255, 255, 0.15);
+    transition: border-color 0.15s ease;
+}
+
+.nav-avatar-btn:hover img {
+    border-color: rgba(255, 255, 255, 0.3);
+}
+
+.nav-avatar-btn.menu-open img {
+    border-color: var(--color-accent, #f39c12);
+}
+
+/* Dropdown menu */
+.nav-dropdown {
+    position: absolute;
+    top: calc(100% + 8px);
+    right: 0;
+    background: linear-gradient(165deg, #1a1a2e 0%, #12121f 100%);
+    border: 1px solid rgba(255, 255, 255, 0.1);
+    border-radius: 6px;
+    min-width: 180px;
+    box-shadow: 0 8px 32px rgba(0, 0, 0, 0.5);
+    opacity: 0;
+    visibility: hidden;
+    transform: translateY(-8px);
+    transition: all 0.2s ease;
+    z-index: 1000;
+    overflow: hidden;
+}
+
+.nav-dropdown.open {
+    opacity: 1;
+    visibility: visible;
+    transform: translateY(0);
+}
+
+/* Gold accent line at top */
+.nav-dropdown::before {
+    content: '';
+    position: absolute;
+    top: 0;
+    left: 0;
+    right: 0;
+    height: 2px;
+    background: linear-gradient(90deg, transparent, var(--color-accent, #f39c12), transparent);
+}
+
+/* User info header */
+.nav-dropdown-header {
+    padding: 12px 14px;
+    border-bottom: 1px solid rgba(255, 255, 255, 0.06);
+    display: flex;
+    align-items: center;
+    gap: 10px;
+}
+
+.nav-dropdown-header img {
+    width: 32px;
+    height: 32px;
+    border-radius: 50%;
+    border: 1px solid rgba(255, 255, 255, 0.1);
+}
+
+.nav-dropdown-header span {
+    font-family: 'Barlow', sans-serif;
+    font-size: 0.85em;
+    font-weight: 600;
+    color: #ccc;
+}
+
+/* Menu items */
+.nav-dropdown-item {
+    font-family: 'Barlow', sans-serif;
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    width: 100%;
+    padding: 10px 14px;
+    background: none;
+    border: none;
+    color: #888;
+    font-size: 0.8em;
+    font-weight: 500;
     cursor: pointer;
     transition: all 0.15s ease;
-    background: transparent;
-    color: #666;
-    display: flex;
-    align-items: center;
-    gap: 6px;
+    text-align: left;
 }
 
-.nav-btn:hover {
-    background: rgba(255, 255, 255, 0.06);
-    color: #999;
+.nav-dropdown-item:hover {
+    background: rgba(255, 255, 255, 0.05);
+    color: #ccc;
 }
 
-.nav-btn svg {
-    width: 12px;
-    height: 12px;
+.nav-dropdown-item svg {
+    width: 14px;
+    height: 14px;
     fill: currentColor;
-    opacity: 0.7;
+    opacity: 0.6;
 }
 
-.nav-btn:hover svg {
+.nav-dropdown-item:hover svg {
     opacity: 1;
+}
+
+.nav-dropdown-item.active {
+    color: var(--color-accent, #f39c12);
+}
+
+.nav-dropdown-item.active svg {
+    opacity: 1;
+}
+
+.nav-dropdown-divider {
+    height: 1px;
+    background: rgba(255, 255, 255, 0.06);
+    margin: 4px 0;
 }
 
 /* Mobile nav */
@@ -331,49 +403,9 @@ h1 {
         padding: 6px 8px;
     }
 
-    .nav-auth {
-        padding: 3px;
-    }
-
-    /* Compact buttons on mobile */
-    .nav-btn {
-        padding: 6px 8px;
-    }
-
-    /* Hide text on mobile, show only icons */
-    .nav-btn .btn-text {
-        display: none;
-    }
-
-    .nav-btn svg {
-        width: 14px;
-        height: 14px;
-    }
-
-    /* Hide username on mobile */
-    .nav-user span {
-        display: none;
-    }
-
-    .nav-user {
-        padding: 6px 8px;
-    }
-
-    /* Hide sync status text on mobile */
-    .sync-status {
-        font-size: 0;
-        min-width: auto;
-    }
-    .sync-status::before {
-        font-size: 12px;
-    }
-    .sync-status.syncing::before { content: '🔄'; }
-    .sync-status.synced::before { content: '✓'; font-size: 14px; }
-    .sync-status.error::before { content: '⚠'; }
-
-    /* Compact user display */
-    .nav-user span {
-        display: none;
+    /* Dropdown adjusts on mobile */
+    .nav-dropdown {
+        right: -8px;
     }
 }
 


### PR DESCRIPTION
## Summary
Simplifies the nav auth section to just show the user avatar. Clicking opens a dropdown menu.

**Dropdown contains:**
- Username header with avatar
- "Edit cards" option (owner only, toggles edit mode)
- "Sign out" option

**Design details:**
- Avatar has subtle border, gold accent when menu open
- Dropdown has broadcast-style gold top accent line
- SVG icons for all actions
- Click outside to close

## Test plan
- [ ] Verify only avatar shows in nav when logged in
- [ ] Click avatar opens dropdown
- [ ] Dropdown shows username at top
- [ ] Owner sees "Edit cards" option
- [ ] "Edit cards" toggles edit mode and closes dropdown
- [ ] "Sign out" works
- [ ] Click outside closes dropdown