### PR TITLE
Add Enter key to submit edit modal

### DIFF
--- a/shared.js
+++ b/shared.js
@@ -809,6 +809,14 @@ class CardEditorModal {
                 this.close();
             }
         });
+
+        // Enter key to save (unless in a select or textarea)
+        modal.addEventListener('keydown', (e) => {
+            if (e.key === 'Enter' && !['SELECT', 'TEXTAREA'].includes(e.target.tagName)) {
+                e.preventDefault();
+                this.save();
+            }
+        });
     }
 
     // Update image preview


### PR DESCRIPTION
## Summary
Fixes #168

Pressing Enter while in the edit modal submits the form (saves the card).

- Works from any input field
- Excludes select and textarea elements where Enter has other meanings

## Test plan
- [ ] Open edit modal for a card
- [ ] Press Enter in any text input field
- [ ] Verify modal saves and closes