### PR TITLE
Fix image processor auth check

### DIFF
--- a/shared.js
+++ b/shared.js
@@ -1063,8 +1063,8 @@ class CardEditorModal {
 
         if (!url || !this.imageProcessor.isEbayUrl(url)) return;
 
-        // Check if gitSync is available and logged in
-        if (typeof gitSync === 'undefined' || !gitSync.isLoggedIn()) {
+        // Check if githubSync is available and logged in
+        if (typeof githubSync === 'undefined' || !githubSync.isLoggedIn()) {
             alert('Please sign in to process images');
             return;
         }
@@ -1091,7 +1091,7 @@ class CardEditorModal {
 
             // Commit via PR (will auto-merge)
             btn.title = 'Creating PR...';
-            const committedPath = await gitSync.commitImageViaPR(
+            const committedPath = await githubSync.commitImageViaPR(
                 path,
                 base64Content,
                 `Add image: ${filename}`


### PR DESCRIPTION
## Summary
- Fixed `processImage()` checking wrong variable name (`gitSync` instead of `githubSync`)
- This caused "please sign in to process images" error even when logged in

## Test plan
- [ ] Open a checklist page while signed in
- [ ] Enable edit mode, click edit on a card
- [ ] Paste an eBay image URL - process button should work without auth error