### PR TITLE
Fix auto-merge workflow for image PRs

### DIFF
--- a/.github/workflows/auto-merge-images.yml
+++ b/.github/workflows/auto-merge-images.yml
@@ -39,12 +39,6 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Approve PR
-        if: steps.check.outputs.should_merge == 'true'
-        run: gh pr review ${{ github.event.pull_request.number }} --approve
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
       - name: Merge PR
         if: steps.check.outputs.should_merge == 'true'
         run: gh pr merge ${{ github.event.pull_request.number }} --squash --delete-branch


### PR DESCRIPTION
## Summary
- Remove the PR approval step since GitHub Actions can't approve PRs by default
- Just merge directly - approval isn't needed for owner-processed images

## Test plan
- [ ] Process an image via the card editor
- [ ] Verify the PR is auto-merged without manual intervention