### PR TITLE
Fix editor placeholder styling and image preview

### DIFF
--- a/shared.css
+++ b/shared.css
@@ -1172,7 +1172,9 @@ body.edit-mode .card:hover {
 }
 
 .card-editor-modal .card-editor-input::placeholder {
-    color: #999 !important;
+    color: #666 !important;
+    font-style: italic;
+    opacity: 0.7;
 }
 
 .card-editor-select {

--- a/shared.js
+++ b/shared.js
@@ -1103,12 +1103,13 @@ class CardEditorModal {
 
             // Update the input field with the file path
             imgInput.value = committedPath;
-            this.updateImagePreview(committedPath);
+            // Show the processed image as preview (path won't work until PR merges)
+            this.updateImagePreview(`data:image/webp;base64,${base64Content}`);
             this.updateProcessButton(committedPath);
             this.setDirty(true);
 
-            // Show success message with timing info
-            btn.title = 'Image will appear after PR merges (~30-60s)';
+            // Show success message
+            btn.title = 'Done! Image committed via PR';
 
         } catch (error) {
             console.error('Image processing failed:', error);


### PR DESCRIPTION
## Summary
- Make placeholder text more visually distinct from entered text (darker, italic, lower opacity)
- After processing an image, show the processed image as preview instead of "No image"

## Changes
- `shared.css`: Placeholder now uses `#666`, `font-style: italic`, `opacity: 0.7`
- `shared.js`: Show base64 preview after processing (path doesn't exist until PR merges)

## Test plan
- [ ] Open card editor - placeholder text should be clearly muted/italic
- [ ] Process an eBay image - preview should show the processed image immediately
- [ ] Save the card - image path is saved, will display after PR auto-merges

Closes #181