### PR TITLE
Move Clear All button to dropdown menu

### DIFF
--- a/jayden-daniels-rookie-checklist.html
+++ b/jayden-daniels-rookie-checklist.html
@@ -203,7 +203,6 @@
         <div class="card-grid" id="chase-cards"></div>
     </div>
 
-    <button class="clear-btn" onclick="checklistManager.clearAll()">Clear All</button>
     </div><!-- end page-content -->
 
     <script src="github-sync.js"></script>

--- a/jmu-pro-players-checklist.html
+++ b/jmu-pro-players-checklist.html
@@ -264,7 +264,6 @@
         <div class="card-grid" id="alternates-cards"></div>
     </div>
 
-    <button class="clear-btn" onclick="checklistManager.clearAll()">Clear All</button>
     </div><!-- end page-content -->
 
     <script src="github-sync.js"></script>

--- a/shared.css
+++ b/shared.css
@@ -369,6 +369,15 @@ h1 {
     opacity: 1;
 }
 
+.nav-dropdown-item.danger {
+    color: #888;
+}
+
+.nav-dropdown-item.danger:hover {
+    background: rgba(255, 82, 82, 0.15);
+    color: #ff5252;
+}
+
 .nav-dropdown-divider {
     height: 1px;
     background: rgba(255, 255, 255, 0.06);

--- a/shared.js
+++ b/shared.js
@@ -199,10 +199,14 @@ class ChecklistManager {
             const safeLogin = sanitizeText(user.login);
             const isOwner = this.isOwner();
 
-            const editItemHtml = isOwner ? `
+            const ownerItemsHtml = isOwner ? `
                 <button class="nav-dropdown-item" id="edit-mode-btn">
                     <svg viewBox="0 0 24 24"><path d="M3 17.25V21h3.75L17.81 9.94l-3.75-3.75L3 17.25zM20.71 7.04c.39-.39.39-1.02 0-1.41l-2.34-2.34c-.39-.39-1.02-.39-1.41 0l-1.83 1.83 3.75 3.75 1.83-1.83z"/></svg>
                     Edit cards
+                </button>
+                <button class="nav-dropdown-item danger" id="clear-all-btn">
+                    <svg viewBox="0 0 24 24"><path d="M6 19c0 1.1.9 2 2 2h8c1.1 0 2-.9 2-2V7H6v12zM19 4h-3.5l-1-1h-5l-1 1H5v2h14V4z"/></svg>
+                    Clear All
                 </button>
                 <div class="nav-dropdown-divider"></div>
             ` : '';
@@ -216,7 +220,7 @@ class ChecklistManager {
                         <img src="${safeAvatarUrl}" alt="">
                         <span>${safeLogin}</span>
                     </div>
-                    ${editItemHtml}
+                    ${ownerItemsHtml}
                     <button class="nav-dropdown-item" id="auth-logout-btn">
                         <svg viewBox="0 0 24 24"><path d="M17 7l-1.41 1.41L18.17 11H8v2h10.17l-2.58 2.58L17 17l5-5zM4 5h8V3H4c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h8v-2H4V5z"/></svg>
                         Sign out
@@ -238,6 +242,8 @@ class ChecklistManager {
                 dropdown.classList.remove('open');
             });
             document.getElementById('auth-logout-btn').onclick = () => this.logout();
+            const clearAllBtn = document.getElementById('clear-all-btn');
+            if (clearAllBtn) clearAllBtn.onclick = () => this.clearAll();
         } else {
             authContent.innerHTML = '';
         }


### PR DESCRIPTION
## Summary
- Moves Clear All from fixed bottom-right position to the owner dropdown menu
- Adds danger styling (red on hover) to make it clear this is destructive
- Removes the always-visible clear button from page HTML

## Test plan
- [ ] Sign in as owner
- [ ] Open dropdown menu - verify "Clear All" appears with trash icon
- [ ] Hover over Clear All - verify red highlight
- [ ] Click Clear All - verify confirmation dialog and functionality
- [ ] Verify old fixed button is gone from bottom right

Closes #176