### PR TITLE
Fix price badge height

### DIFF
--- a/shared.css
+++ b/shared.css
@@ -713,6 +713,7 @@ select, input[type="text"] {
     font-size: 13px;
     font-weight: 400;
     letter-spacing: 0.02em;
+    line-height: 1;
     z-index: 10;
 }
 


### PR DESCRIPTION
Add line-height: 1 to tighten up the Bebas Neue font in price badges.