### PR TITLE
Fix price badge styling and simplify image placeholder

### DIFF
--- a/shared.css
+++ b/shared.css
@@ -702,18 +702,16 @@ select, input[type="text"] {
    Price Badge
    ============================================ */
 .price-badge {
-    font-family: 'Bebas Neue', sans-serif;
+    font-family: 'Barlow', sans-serif;
     position: absolute;
     top: 8px;
     right: 8px;
     background: var(--color-success);
     color: white;
-    padding: 2px 8px;
+    padding: 3px 8px;
     border-radius: var(--radius-sm);
-    font-size: 13px;
-    font-weight: 400;
-    letter-spacing: 0.02em;
-    line-height: 1;
+    font-size: 12px;
+    font-weight: 600;
     z-index: 10;
 }
 

--- a/shared.js
+++ b/shared.js
@@ -458,10 +458,9 @@ const CardRenderer = {
     // Render card image with fallback
     renderCardImage(imgSrc, alt, searchUrl) {
         if (imgSrc) {
-            // If image fails to load, show helpful message (may be processing)
-            return `<a href="${searchUrl}" target="_blank"><img class="card-image" src="${imgSrc}" alt="${alt}" loading="lazy" onerror="this.outerHTML='<a href=\\'${searchUrl}\\' target=\\'_blank\\' class=\\'card-image placeholder\\'>Image loading... (new images may take 1-2 min)</a>'"></a>`;
+            return `<a href="${searchUrl}" target="_blank"><img class="card-image" src="${imgSrc}" alt="${alt}" loading="lazy" onerror="this.outerHTML='<a href=\\'${searchUrl}\\' target=\\'_blank\\' class=\\'card-image placeholder\\'>No image</a>'"></a>`;
         }
-        return `<a href="${searchUrl}" target="_blank" class="card-image placeholder">Click to view on eBay</a>`;
+        return `<a href="${searchUrl}" target="_blank" class="card-image placeholder">No image</a>`;
     },
 
     // Render owned checkbox or badge based on read-only state


### PR DESCRIPTION
## Summary
- Switch price badge from Bebas Neue to Barlow font for better proportions
- Simplify image placeholder from long message to just "No image"

## Test plan
- [ ] Check price badges look less stretched
- [ ] Verify missing images show "No image" placeholder