### PR TITLE
Add AUTO badge for autographed cards

### DIFF
--- a/jayden-daniels-rookie-checklist.html
+++ b/jayden-daniels-rookie-checklist.html
@@ -338,6 +338,7 @@
             return `
                 <div class="card ${owned ? 'owned' : ''}" data-price="${price}" data-type="${card.type}">
                     <div class="card-image-wrapper">
+                        ${CardRenderer.renderAutoBadge(card)}
                         ${CardRenderer.renderPriceBadge(price)}
                         ${CardRenderer.renderCardImage(card.img, card.set, searchUrl)}
                     </div>

--- a/jmu-pro-players-checklist.html
+++ b/jmu-pro-players-checklist.html
@@ -405,6 +405,7 @@
             return `
                 <div class="card ${owned ? 'owned' : ''}" data-price="${price}" data-sport="${card.sport}">
                     <div class="card-image-wrapper">
+                        ${CardRenderer.renderAutoBadge(card)}
                         ${CardRenderer.renderPriceBadge(price, jmuPriceThresholds)}
                         ${CardRenderer.renderCardImage(card.img, card.set, searchUrl)}
                     </div>

--- a/shared.css
+++ b/shared.css
@@ -718,6 +718,23 @@ select, input[type="text"] {
 .price-badge.mid { background: var(--color-warning); }
 .price-badge.high { background: var(--color-error); }
 
+/* Auto Badge (autographed cards) */
+.auto-badge {
+    font-family: 'Barlow', sans-serif;
+    position: absolute;
+    top: 8px;
+    left: 8px;
+    background: linear-gradient(135deg, #d4af37 0%, #b8960c 100%);
+    color: #fff;
+    padding: 3px 8px;
+    border-radius: var(--radius-sm);
+    font-size: 11px;
+    font-weight: 700;
+    letter-spacing: 0.05em;
+    z-index: 10;
+    text-shadow: 0 1px 1px rgba(0,0,0,0.2);
+}
+
 .price-link {
     font-family: 'Barlow', sans-serif;
     display: inline-block;

--- a/shared.js
+++ b/shared.js
@@ -455,6 +455,12 @@ const CardRenderer = {
         return `<span class="price-badge ${priceClass}">$${displayPrice}</span>`;
     },
 
+    // Render auto badge HTML (for autographed cards)
+    renderAutoBadge(card) {
+        if (!card.auto) return '';
+        return `<span class="auto-badge">AUTO</span>`;
+    },
+
     // Render card image with fallback
     renderCardImage(imgSrc, alt, searchUrl) {
         if (imgSrc) {

--- a/washington-qbs-rookie-checklist.html
+++ b/washington-qbs-rookie-checklist.html
@@ -600,6 +600,7 @@
             return `<div class="${cardClass}">
                 <div class="card-image-wrapper">
                     ${qb.superBowl ? '<span class="super-bowl-badge">SUPER BOWL</span>' : ''}
+                    ${CardRenderer.renderAutoBadge(qb)}
                     ${CardRenderer.renderPriceBadge(qb.price)}
                     ${CardRenderer.renderCardImage(qb.img, qb.player, searchUrl)}
                 </div>


### PR DESCRIPTION
## Summary
- Adds gold "AUTO" badge in top-left corner for cards with `auto: true`
- Uses gold gradient to evoke signatures/autographs
- Mirrors price badge style on opposite corner

## Test plan
- [ ] Mark a card as autographed in the editor
- [ ] Verify gold AUTO badge appears in top-left
- [ ] Verify badge doesn't appear on non-auto cards