### PR TITLE
Align terminology: rename qb/qbs to card/cards

### DIFF
--- a/seed/washington-qbs.json
+++ b/seed/washington-qbs.json
@@ -25,7 +25,7 @@
       "description": "Current era"
     }
   },
-  "qbs": [
+  "cards": [
     {
       "years": "1982-1985",
       "record": "39-13",

--- a/washington-qbs-rookie-checklist.html
+++ b/washington-qbs-rookie-checklist.html
@@ -390,17 +390,17 @@
     <script src="github-sync.js"></script>
     <script src="shared.js"></script>
     <script>
-        // QB data loaded from external JSON file
-        let qbs = null;
+        // Card data loaded from external JSON file
+        let cards = null;
         let checklistData = null;
 
-        async function loadQbData() {
+        async function loadCardData() {
             // Try to load from gist first (gist is source of truth)
             if (window.githubSync?.isLoggedIn()) {
                 const gistData = await githubSync.loadCardData('washington-qbs');
                 if (gistData) {
                     checklistData = gistData;
-                    qbs = checklistData.qbs;
+                    cards = checklistData.cards;
                     return;
                 }
             } else {
@@ -408,7 +408,7 @@
                 const publicData = await githubSync.loadPublicCardData('washington-qbs');
                 if (publicData) {
                     checklistData = publicData;
-                    qbs = checklistData.qbs;
+                    cards = checklistData.cards;
                     return;
                 }
             }
@@ -416,10 +416,10 @@
             // Fall back to seed data
             const response = await fetch('seed/washington-qbs.json');
             if (!response.ok) {
-                throw new Error('Failed to load QB data');
+                throw new Error('Failed to load card data');
             }
             checklistData = await response.json();
-            qbs = checklistData.qbs;
+            cards = checklistData.cards;
 
             // Save seed data to gist so it becomes the source of truth
             if (window.githubSync?.isLoggedIn()) {
@@ -439,8 +439,8 @@
         });
 
         // Wrapper functions for backward compatibility
-        function getCardId(qb) {
-            return btoa(qb.player + qb.set + qb.num).replace(/[^a-zA-Z0-9]/g, '');
+        function getCardId(card) {
+            return btoa(card.player + card.set + card.num).replace(/[^a-zA-Z0-9]/g, '');
         }
 
         function isOwned(cardId) {
@@ -494,14 +494,14 @@
             }
         }
 
-        function getCardYear(qb) {
-            const match = qb.set.match(/(\d{4})/);
+        function getCardYear(card) {
+            const match = card.set.match(/(\d{4})/);
             return match ? parseInt(match[1]) : 0;
         }
 
-        function getWinPct(qb) {
-            if (!qb.record || qb.record === '-') return 0;
-            const parts = qb.record.split('-');
+        function getWinPct(card) {
+            if (!card.record || card.record === '-') return 0;
+            const parts = card.record.split('-');
             if (parts.length < 2) return 0;
             const wins = parseInt(parts[0]) || 0;
             const losses = parseInt(parts[1]) || 0;
@@ -509,23 +509,23 @@
             return total > 0 ? wins / total : 0;
         }
 
-        function getWins(qb) {
-            if (!qb.record || qb.record === '-') return 0;
-            const parts = qb.record.split('-');
+        function getWins(card) {
+            if (!card.record || card.record === '-') return 0;
+            const parts = card.record.split('-');
             return parseInt(parts[0]) || 0;
         }
 
-        function getGamesPlayed(qb) {
-            if (!qb.record || qb.record === '-') return 0;
-            const parts = qb.record.split('-');
+        function getGamesPlayed(card) {
+            if (!card.record || card.record === '-') return 0;
+            const parts = card.record.split('-');
             if (parts.length < 2) return 0;
             const wins = parseInt(parts[0]) || 0;
             const losses = parseInt(parts[1]) || 0;
             return wins + losses;
         }
 
-        function sortQbs(qbsToSort, sortBy) {
-            const sorted = [...qbsToSort];
+        function sortCards(cardsToSort, sortBy) {
+            const sorted = [...cardsToSort];
             switch (sortBy) {
                 case 'year':
                     sorted.sort((a, b) => getCardYear(a) - getCardYear(b));
@@ -566,17 +566,17 @@
             return sorted;
         }
 
-        function renderQbCard(qb) {
-            const cardId = qb.collectionLink ? null : getCardId(qb);
+        function createCardElement(card) {
+            const cardId = card.collectionLink ? null : getCardId(card);
             const cardOwned = cardId ? isOwned(cardId) : false;
 
             // Special handling for collection link cards (Jayden Daniels full checklist)
-            if (qb.collectionLink) {
-                const total = jaydenDanielsStats.total || qb.cardCount;
+            if (card.collectionLink) {
+                const total = jaydenDanielsStats.total || card.cardCount;
                 const jdBadge = jaydenDanielsStats.owned > 0
                     ? `${jaydenDanielsStats.owned} / ${total}`
                     : `${total} CARDS`;
-                return `<div class="card collection-link" onclick="window.location.href='${qb.collectionLink}'">
+                return `<div class="card collection-link" onclick="window.location.href='${card.collectionLink}'">
                     <div class="card-image-wrapper">
                         <span class="collection-badge">${jdBadge}</span>
                         <div class="card-stack">
@@ -585,32 +585,32 @@
                             <img src="jayden-daniels-cards/resurgence_196.webp" alt="" loading="lazy">
                         </div>
                     </div>
-                    <div class="player-name">${qb.player}</div>
-                    <div class="player-years">${qb.years} &bull; ${qb.record}</div>
-                    ${qb.playoff !== '-' ? `<div class="player-record">Playoffs: ${qb.playoff}</div>` : ''}
-                    ${CardRenderer.renderAchievements(qb.achievement)}
-                    <a href="${qb.collectionLink}" class="collection-cta">View Full Collection →</a>
+                    <div class="player-name">${card.player}</div>
+                    <div class="player-years">${card.years} &bull; ${card.record}</div>
+                    ${card.playoff !== '-' ? `<div class="player-record">Playoffs: ${card.playoff}</div>` : ''}
+                    ${CardRenderer.renderAchievements(card.achievement)}
+                    <a href="${card.collectionLink}" class="collection-cta">View Full Collection →</a>
                 </div>`;
             }
 
-            const cardClass = `card ${cardOwned ? 'owned' : ''} ${qb.superBowl ? 'super-bowl' : ''}`;
-            const searchUrl = CardRenderer.getEbayUrl(qb.search);
-            const scpUrl = CardRenderer.getScpUrl(encodeURIComponent(qb.player + ' rookie'));
+            const cardClass = `card ${cardOwned ? 'owned' : ''} ${card.superBowl ? 'super-bowl' : ''}`;
+            const searchUrl = CardRenderer.getEbayUrl(card.search);
+            const scpUrl = CardRenderer.getScpUrl(encodeURIComponent(card.player + ' rookie'));
 
             return `<div class="${cardClass}">
                 <div class="card-image-wrapper">
-                    ${qb.superBowl ? '<span class="super-bowl-badge">SUPER BOWL</span>' : ''}
-                    ${CardRenderer.renderAutoBadge(qb)}
-                    ${CardRenderer.renderPriceBadge(qb.price)}
-                    ${CardRenderer.renderCardImage(qb.img, qb.player, searchUrl)}
+                    ${card.superBowl ? '<span class="super-bowl-badge">SUPER BOWL</span>' : ''}
+                    ${CardRenderer.renderAutoBadge(card)}
+                    ${CardRenderer.renderPriceBadge(card.price)}
+                    ${CardRenderer.renderCardImage(card.img, card.player, searchUrl)}
                 </div>
-                <div class="player-name">${qb.player}</div>
-                <div class="player-years">${qb.years} &bull; ${qb.record}</div>
-                ${qb.playoff !== '-' ? `<div class="player-record">Playoffs: ${qb.playoff}</div>` : ''}
+                <div class="player-name">${card.player}</div>
+                <div class="player-years">${card.years} &bull; ${card.record}</div>
+                ${card.playoff !== '-' ? `<div class="player-record">Playoffs: ${card.playoff}</div>` : ''}
                 <div class="card-info">
-                    <span class="card-set">${qb.set}</span> ${qb.num}
+                    <span class="card-set">${card.set}</span> ${card.num}
                 </div>
-                ${CardRenderer.renderAchievements(qb.achievement)}
+                ${CardRenderer.renderAchievements(card.achievement)}
                 <div class="card-actions${checklistManager.isReadOnly && !cardOwned ? ' links-only' : ''}">
                     ${!checklistManager.isReadOnly ? `<label class="checkbox-wrapper">
                         <input type="checkbox" id="${cardId}" ${cardOwned ? 'checked' : ''} onchange="toggleOwned('${cardId}')">
@@ -629,12 +629,12 @@
             const statusFilter = document.getElementById('status-filter').value;
             const searchTerm = document.getElementById('search').value.toLowerCase();
 
-            let filtered = qbs.filter(qb => {
-                if (eraFilter !== 'all' && qb.era !== eraFilter) return false;
-                const cardId = qb.collectionLink ? null : getCardId(qb);
+            let filtered = cards.filter(card => {
+                if (eraFilter !== 'all' && card.era !== eraFilter) return false;
+                const cardId = card.collectionLink ? null : getCardId(card);
                 if (statusFilter === 'owned' && (!cardId || !isOwned(cardId))) return false;
                 if (statusFilter === 'needed' && cardId && isOwned(cardId)) return false;
-                if (searchTerm && !qb.player.toLowerCase().includes(searchTerm)) return false;
+                if (searchTerm && !card.player.toLowerCase().includes(searchTerm)) return false;
                 return true;
             });
 
@@ -642,10 +642,10 @@
 
             // For non-default sort, render as flat list
             if (sortBy !== 'default') {
-                const sorted = sortQbs(filtered, sortBy);
+                const sorted = sortCards(filtered, sortBy);
                 let html = '<div class="era-section"><div class="cards-grid">';
-                sorted.forEach(qb => {
-                    html += renderQbCard(qb);
+                sorted.forEach(card => {
+                    html += createCardElement(card);
                 });
                 html += '</div></div>';
                 container.innerHTML = html;
@@ -662,8 +662,8 @@
                 modern: { title: "Modern Era (2020-2025)", cards: [] }
             };
 
-            filtered.forEach(qb => {
-                eras[qb.era].cards.push(qb);
+            filtered.forEach(card => {
+                eras[card.era].cards.push(card);
             });
 
             let html = '';
@@ -672,8 +672,8 @@
                 html += `<div class="era-section">
                     <h2 class="era-title">${era.title}</h2>
                     <div class="cards-grid">`;
-                era.cards.forEach(qb => {
-                    html += renderQbCard(qb);
+                era.cards.forEach(card => {
+                    html += createCardElement(card);
                 });
                 html += '</div></div>';
             });
@@ -682,13 +682,13 @@
             updateStats(filtered);
         }
 
-        // Compute stats for saving (always uses all QBs, not filtered)
+        // Compute stats for saving (always uses all cards, not filtered)
         function computeStats() {
-            const countableQbs = qbs.filter(qb => !qb.collectionLink);
+            const countableCards = cards.filter(card => !card.collectionLink);
             let ownedCount = 0, totalValue = 0, ownedValue = 0, neededValue = 0;
-            countableQbs.forEach(qb => {
-                const price = qb.price || 0;
-                const owned = isOwned(getCardId(qb));
+            countableCards.forEach(card => {
+                const price = card.price || 0;
+                const owned = isOwned(getCardId(card));
                 totalValue += price;
                 if (owned) {
                     ownedCount++;
@@ -699,22 +699,22 @@
             });
             return {
                 owned: ownedCount,
-                total: countableQbs.length,
+                total: countableCards.length,
                 ownedValue: Math.round(ownedValue),
                 neededValue: Math.round(neededValue)
             };
         }
 
-        function updateStats(filteredQbs) {
+        function updateStats(filteredCards) {
             // Use filtered list if provided, otherwise use all
-            const visibleQbs = filteredQbs || qbs;
+            const visibleCards = filteredCards || cards;
             // Exclude collection link cards from counts
-            const countableQbs = visibleQbs.filter(qb => !qb.collectionLink);
-            const totalCount = countableQbs.length;
+            const countableCards = visibleCards.filter(card => !card.collectionLink);
+            const totalCount = countableCards.length;
             let ownedCount = 0, totalValue = 0, ownedValue = 0, neededValue = 0;
-            countableQbs.forEach(qb => {
-                const price = qb.price || 0;
-                const owned = isOwned(getCardId(qb));
+            countableCards.forEach(card => {
+                const price = card.price || 0;
+                const owned = isOwned(getCardId(card));
                 totalValue += price;
                 if (owned) {
                     ownedCount++;
@@ -743,9 +743,9 @@
         // Initialize edit mode manager
         const editModeManager = new EditModeManager(checklistManager);
 
-        // Save QB data to GitHub repo
-        async function saveQbDataToRepo() {
-            checklistData.qbs = qbs;
+        // Save card data to GitHub repo
+        async function saveCardDataToRepo() {
+            checklistData.cards = cards;
             const success = await githubSync.saveCardData('washington-qbs', checklistData);
             if (success) {
                 checklistManager.setSyncStatus('synced', 'Saved');
@@ -757,13 +757,13 @@
 
         // Initialize card editor modal
         const cardEditor = new CardEditorModal({
-            showCardNameField: false,  // QBs don't use card name/variant
+            showCardNameField: false,  // This page doesn't use card name/variant
             imageFolder: 'washington-qbs-cards',
             onSave: async (cardId, cardData, isNew) => {
                 if (isNew) {
-                    // Add new QB
-                    const newQb = {
-                        player: cardData.player || 'Unknown QB',
+                    // Add new card
+                    const newCard = {
+                        player: cardData.player || 'Unknown Player',
                         years: cardData.years || 'TBD',
                         record: cardData.record || '0-0',
                         playoff: '-',
@@ -774,49 +774,49 @@
                         img: cardData.img
                     };
                     if (!cardData.ebay) {
-                        newQb.search = `${newQb.player.replace(/\s+/g, '+')}+rookie+card`;
+                        newCard.search = `${newCard.player.replace(/\s+/g, '+')}+rookie+card`;
                     } else {
-                        newQb.search = cardData.ebay;
+                        newCard.search = cardData.ebay;
                     }
-                    insertQbSorted(newQb);
-                    console.log('Added new QB:', newQb);
+                    insertCardSorted(newCard);
+                    console.log('Added new card:', newCard);
                 } else {
-                    // Update existing QB
-                    const found = findQbWithIndex(cardId);
+                    // Update existing card
+                    const found = findCardWithIndex(cardId);
                     if (found) {
-                        const { qb, index } = found;
-                        if (cardData.player) qb.player = cardData.player;
-                        qb.set = cardData.set;
-                        qb.num = cardData.num;
+                        const { card: foundCard, index } = found;
+                        if (cardData.player) foundCard.player = cardData.player;
+                        foundCard.set = cardData.set;
+                        foundCard.num = cardData.num;
                         // Handle optional fields - set if present, delete if cleared
-                        if ('price' in cardData) qb.price = cardData.price;
-                        else delete qb.price;
-                        if ('img' in cardData) qb.img = cardData.img;
-                        else delete qb.img;
-                        if (cardData.ebay) qb.search = cardData.ebay;
+                        if ('price' in cardData) foundCard.price = cardData.price;
+                        else delete foundCard.price;
+                        if ('img' in cardData) foundCard.img = cardData.img;
+                        else delete foundCard.img;
+                        if (cardData.ebay) foundCard.search = cardData.ebay;
                         // Re-sort: remove from current position and re-insert sorted
-                        qbs.splice(index, 1);
-                        insertQbSorted(qb);
-                        console.log('Updated QB:', qb);
+                        cards.splice(index, 1);
+                        insertCardSorted(foundCard);
+                        console.log('Updated card:', foundCard);
                     }
                 }
                 render();
                 editModeManager.updateCardEditControls();
                 // Save to GitHub repo
                 checklistManager.setSyncStatus('syncing', 'Saving...');
-                await saveQbDataToRepo();
+                await saveCardDataToRepo();
             },
             onDelete: async (cardId) => {
-                const idx = qbs.findIndex(qb => getCardId(qb) === cardId);
+                const idx = cards.findIndex(card => getCardId(card) === cardId);
                 if (idx !== -1) {
-                    qbs.splice(idx, 1);
-                    console.log('Deleted QB:', cardId);
+                    cards.splice(idx, 1);
+                    console.log('Deleted card:', cardId);
                 }
                 render();
                 editModeManager.updateCardEditControls();
                 // Save to GitHub repo
                 checklistManager.setSyncStatus('syncing', 'Saving...');
-                await saveQbDataToRepo();
+                await saveCardDataToRepo();
             }
         });
 
@@ -827,14 +827,14 @@
             }
         });
 
-        // Helper to find QB by ID
-        function findQbById(cardId) {
-            return qbs.find(qb => getCardId(qb) === cardId);
+        // Helper to find card by ID
+        function findCardById(cardId) {
+            return cards.find(card => getCardId(card) === cardId);
         }
 
-        function findQbWithIndex(cardId) {
-            const idx = qbs.findIndex(qb => getCardId(qb) === cardId);
-            if (idx !== -1) return { qb: qbs[idx], index: idx };
+        function findCardWithIndex(cardId) {
+            const idx = cards.findIndex(card => getCardId(card) === cardId);
+            if (idx !== -1) return { card: cards[idx], index: idx };
             return null;
         }
 
@@ -850,30 +850,30 @@
             return match ? parseInt(match[0]) : 9999;
         }
 
-        function insertQbSorted(qb) {
-            const idx = qbs.findIndex(q => {
-                // Sort by starting year (when they were QB)
-                const startA = getStartYear(qb.years);
+        function insertCardSorted(card) {
+            const idx = cards.findIndex(q => {
+                // Sort by starting year
+                const startA = getStartYear(card.years);
                 const startB = getStartYear(q.years);
                 if (startB > startA) return true;
                 if (startB < startA) return false;
-                // Same QB era - sort by player name
-                if (q.player > qb.player) return true;
-                if (q.player < qb.player) return false;
+                // Same era - sort by player name
+                if (q.player > card.player) return true;
+                if (q.player < card.player) return false;
                 // Same player - sort by card year
-                const setYearA = getSetYear(qb.set);
+                const setYearA = getSetYear(card.set);
                 const setYearB = getSetYear(q.set);
                 if (setYearB > setYearA) return true;
                 if (setYearB < setYearA) return false;
                 // Same set year - sort by set name then number
-                if (q.set > qb.set) return true;
-                if (q.set < qb.set) return false;
-                const numA = parseInt((qb.num || '').replace(/\D/g, '')) || 0;
+                if (q.set > card.set) return true;
+                if (q.set < card.set) return false;
+                const numA = parseInt((card.num || '').replace(/\D/g, '')) || 0;
                 const numB = parseInt((q.num || '').replace(/\D/g, '')) || 0;
                 return numB > numA;
             });
-            if (idx === -1) qbs.push(qb);
-            else qbs.splice(idx, 0, qb);
+            if (idx === -1) cards.push(card);
+            else cards.splice(idx, 0, card);
         }
 
         // Wire up edit mode to show/hide add button and handle card edits
@@ -886,18 +886,18 @@
             }
         };
 
-        // Handle card edit click - open editor with QB data
+        // Handle card edit click - open editor with card data
         editModeManager.onCardEditClick = (cardId, cardElement) => {
-            const qb = findQbById(cardId);
-            if (qb) {
-                cardEditor.open(cardId, qb);
+            const card = findCardById(cardId);
+            if (card) {
+                cardEditor.open(cardId, card);
             }
         };
 
         // Initialize
         async function init() {
             try {
-                await loadQbData();
+                await loadCardData();
                 await checklistManager.init();
                 editModeManager.init();
                 cardEditor.init();
@@ -907,7 +907,7 @@
             } catch (err) {
                 console.error('Failed to initialize:', err);
                 document.querySelector('.page-content').innerHTML =
-                    '<p style="color:red;padding:20px;">Failed to load QB data. Please refresh the page.</p>';
+                    '<p style="color:red;padding:20px;">Failed to load card data. Please refresh the page.</p>';
             }
         }
         init();


### PR DESCRIPTION
## Summary
- Renamed `qbs` variable to `cards` and `qb` to `card` throughout Washington QBs page
- Renamed functions to match other pages: `loadQbData` -> `loadCardData`, `renderQbCard` -> `createCardElement`, `sortQbs` -> `sortCards`, etc.
- Updated seed file array key from `"qbs"` to `"cards"`
- Aligns terminology with Jayden Daniels and JMU checklist pages for consistency

## Test plan
- [ ] Open Washington QBs page, verify cards display correctly
- [ ] Toggle edit mode, verify cards can be edited and saved
- [ ] Add a new card, verify it saves and displays