### PR TITLE
Hide empty sections when filters are applied

### DIFF
--- a/jmu-pro-players-checklist.html
+++ b/jmu-pro-players-checklist.html
@@ -346,6 +346,14 @@
                 if (searchTerm && !cardText.includes(searchTerm)) show = false;
                 c.style.display = show ? '' : 'none';
             });
+
+            // Hide sections with no visible cards
+            ['football', 'mlb', 'nba', 'mls'].forEach(section => {
+                const sectionEl = document.getElementById(`${section}-section`);
+                const visibleCards = sectionEl.querySelectorAll('.card:not([style*="display: none"])');
+                sectionEl.style.display = visibleCards.length > 0 ? '' : 'none';
+            });
+
             updateStats();
         }
 

--- a/shared.js
+++ b/shared.js
@@ -443,6 +443,17 @@ const FilterUtils = {
             card.style.display = show ? '' : 'none';
         });
 
+        // Hide sections with no visible cards
+        if (options.sections) {
+            options.sections.forEach(sectionId => {
+                const section = document.getElementById(sectionId);
+                if (section) {
+                    const visibleCards = section.querySelectorAll('.card:not([style*="display: none"])');
+                    section.style.display = visibleCards.length > 0 ? '' : 'none';
+                }
+            });
+        }
+
         // Call update callback if provided
         if (options.onFilter) options.onFilter();
     }


### PR DESCRIPTION
## Summary
- JMU page now hides sport sections (Football, MLB, NBA, MLS) when all cards in them are filtered out
- Added `sections` option to `FilterUtils.applyFilters()` for reuse
- Washington QBs already handled this correctly

## Test plan
- [ ] Go to JMU page, filter by "Owned Only" - sections with no owned cards should disappear
- [ ] Search for a player name - only sections containing matches should show
- [ ] Clear filters - all sections should reappear

Closes #231