### PR TITLE
Add version.json for accurate deployment verification

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,44 @@
+name: Deploy to GitHub Pages
+
+on:
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Generate version.json
+        run: |
+          echo "{\"commit\": \"${GITHUB_SHA:0:7}\", \"url\": \"https://github.com/$GITHUB_REPOSITORY/commit/$GITHUB_SHA\"}" > version.json
+
+      - name: Setup Pages
+        uses: actions/configure-pages@v4
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: .
+
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/shared.js
+++ b/shared.js
@@ -72,15 +72,14 @@ const AuthUI = {
 
     async loadCommitHash() {
         try {
-            const response = await fetch('https://api.github.com/repos/iammike/sports-card-checklists/commits/main');
+            const response = await fetch('version.json');
             const data = await response.json();
-            const shortHash = data.sha.substring(0, 7);
             const el = document.getElementById('commit-hash');
             if (el) {
-                el.innerHTML = `<a href="${data.html_url}" target="_blank">${shortHash}</a>`;
+                el.innerHTML = `<a href="${data.url}" target="_blank">${data.commit}</a>`;
             }
         } catch (e) {
-            // Silently fail
+            // Silently fail - version.json may not exist locally
         }
     }
 };
@@ -280,15 +279,14 @@ class ChecklistManager {
     // Load and display commit hash in dropdown
     async loadCommitHash() {
         try {
-            const response = await fetch('https://api.github.com/repos/iammike/sports-card-checklists/commits/main');
+            const response = await fetch('version.json');
             const data = await response.json();
-            const shortHash = data.sha.substring(0, 7);
             const el = document.getElementById('commit-hash');
             if (el) {
-                el.innerHTML = `<a href="${data.html_url}" target="_blank">${shortHash}</a>`;
+                el.innerHTML = `<a href="${data.url}" target="_blank">${data.commit}</a>`;
             }
         } catch (e) {
-            // Silently fail
+            // Silently fail - version.json may not exist locally
         }
     }
 

--- a/version.json
+++ b/version.json
@@ -1,0 +1,1 @@
+{"commit": "local", "url": "#"}


### PR DESCRIPTION
## Summary
- GitHub Action generates `version.json` with actual commit hash at deploy time
- Code fetches from `version.json` instead of GitHub API
- Displayed commit hash now accurately reflects what's deployed

## Required: Change Pages Settings
After merging, you need to update GitHub Pages settings:
1. Go to repo Settings > Pages
2. Under "Build and deployment", change Source from "Deploy from a branch" to "GitHub Actions"

## Test plan
- [ ] Merge PR
- [ ] Change Pages settings to GitHub Actions
- [ ] Wait for deployment
- [ ] Verify commit hash in dropdown matches actual deployed code