### PR TITLE
Clarify stat labels and increase stat font sizes

### DIFF
--- a/index.html
+++ b/index.html
@@ -318,7 +318,7 @@
         }
         .aggregate-stat-value {
             font-family: 'Bebas Neue', sans-serif;
-            font-size: 3.2em;
+            font-size: 3.5em;
             font-weight: 400;
             line-height: 1;
             margin-bottom: 4px;

--- a/jayden-daniels-rookie-checklist.html
+++ b/jayden-daniels-rookie-checklist.html
@@ -119,7 +119,7 @@
             </div>
             <div class="stat">
                 <div class="stat-value" id="total-count">0</div>
-                <div class="stat-label">Total Cards</div>
+                <div class="stat-label">Base Cards</div>
             </div>
             <div class="stat">
                 <div class="stat-value highlight" id="total-value">$0</div>

--- a/jmu-pro-players-checklist.html
+++ b/jmu-pro-players-checklist.html
@@ -201,7 +201,7 @@
             </div>
             <div class="stat">
                 <div class="stat-value" id="total-count">0</div>
-                <div class="stat-label">Total Cards</div>
+                <div class="stat-label">Main Cards</div>
             </div>
             <div class="stat">
                 <div class="stat-value highlight" id="total-value">$0</div>

--- a/shared.css
+++ b/shared.css
@@ -482,7 +482,7 @@ h1 {
 
 .stat-value {
     font-family: 'Bebas Neue', sans-serif;
-    font-size: 3em;
+    font-size: 3.5em;
     font-weight: 400;
     letter-spacing: 0.02em;
     color: #c8c8c8;


### PR DESCRIPTION
## Summary
- Changed "Total Cards" to "Base Cards" on Jayden Daniels page to clarify it only counts base cards
- Changed "Total Cards" to "Main Cards" on JMU page to clarify it only counts main checklist cards
- Increased stat font sizes for better visual impact (3em → 3.5em for stat-value, 3.2em → 3.5em for aggregate-stat-value)

Closes #192, closes #86

## Test plan
- [ ] Verify Jayden Daniels page shows "Base Cards" label
- [ ] Verify JMU page shows "Main Cards" label
- [ ] Verify stat numbers are larger and more readable on all pages
- [ ] Verify index page aggregate stats are also larger