### PR TITLE
Fix stat sizing and auto badge positioning

### DIFF
--- a/index.html
+++ b/index.html
@@ -318,12 +318,17 @@
         }
         .aggregate-stat-value {
             font-family: 'Bebas Neue', sans-serif;
-            font-size: 3.5em;
+            font-size: 3.2em;
             font-weight: 400;
             line-height: 1;
             margin-bottom: 4px;
             color: #c8c8c8;
             letter-spacing: 0.02em;
+        }
+        /* Larger size for owned/total count stats to fill their boxes */
+        #agg-owned,
+        #agg-total {
+            font-size: 3.5em;
         }
         .aggregate-stat-value.highlight {
             color: #f39c12;

--- a/seed/jmu-pro-players.json
+++ b/seed/jmu-pro-players.json
@@ -139,7 +139,8 @@
         "price": 2,
         "search": "curtis+keaton+2000+bowman+certified+auto",
         "img": "jmu-cards/keaton_2000_bowmancertified.webp",
-        "alternate": true
+        "alternate": true,
+        "auto": true
       },
       {
         "player": "Curtis Keaton",

--- a/shared.css
+++ b/shared.css
@@ -482,12 +482,18 @@ h1 {
 
 .stat-value {
     font-family: 'Bebas Neue', sans-serif;
-    font-size: 3.5em;
+    font-size: 3em;
     font-weight: 400;
     letter-spacing: 0.02em;
     color: #c8c8c8;
     line-height: 1;
     margin-bottom: 4px;
+}
+
+/* Larger size for owned/total count stats to fill their boxes */
+#owned-count,
+#total-count {
+    font-size: 3.5em;
 }
 
 .stat-value.highlight {
@@ -736,12 +742,12 @@ select, input[type="text"] {
 .price-badge.mid { background: var(--color-warning); }
 .price-badge.high { background: var(--color-error); }
 
-/* Auto Badge (autographed cards) */
+/* Auto Badge (autographed cards) - positioned below price badge */
 .auto-badge {
     font-family: 'Barlow', sans-serif;
     position: absolute;
-    top: 8px;
-    left: 8px;
+    top: 34px;
+    right: 8px;
     background: linear-gradient(135deg, #d4af37 0%, #b8960c 100%);
     color: #fff;
     padding: 3px 8px;


### PR DESCRIPTION
## Summary
- Fixed stat sizing: reverted general increase, now only owned/total count stats are 3.5em (value stays at 3em)
- Moved auto badge to the right side below the price badge to avoid overlap with the edit button
- Added `auto: true` to Curtis Keaton card in JMU seed data to test badge display

## Test plan
- [ ] Verify owned/total stats are larger and fill their boxes better
- [ ] Verify value stat stayed the same size
- [ ] Check Curtis Keaton card on JMU page shows gold "AUTO" badge below the price badge
- [ ] Verify auto badge doesn't overlap with edit button or price badge