### PR TITLE
Fix auto field not being saved on JMU and Washington QBs pages

### DIFF
--- a/jmu-pro-players-checklist.html
+++ b/jmu-pro-players-checklist.html
@@ -602,6 +602,8 @@
                         else delete card.price;
                         if ('img' in cardData) card.img = cardData.img;
                         else delete card.img;
+                        if ('auto' in cardData) card.auto = cardData.auto;
+                        else delete card.auto;
                         if (cardData.ebay) card.search = cardData.ebay;
                         // Remove from old category
                         cards[oldCategory].splice(index, 1);

--- a/washington-qbs-rookie-checklist.html
+++ b/washington-qbs-rookie-checklist.html
@@ -800,6 +800,8 @@
                         else delete foundCard.price;
                         if ('img' in cardData) foundCard.img = cardData.img;
                         else delete foundCard.img;
+                        if ('auto' in cardData) foundCard.auto = cardData.auto;
+                        else delete foundCard.auto;
                         if (cardData.ebay) foundCard.search = cardData.ebay;
                         // Re-sort: remove from current position and re-insert sorted
                         cards.splice(index, 1);


### PR DESCRIPTION
## Summary
The onSave callbacks on JMU and Washington QBs pages manually copy specific fields but were missing the `auto` field. Added handling so autograph status is properly saved.

## Test plan
- [ ] Go to JMU page, edit Arthur Moats card, check "Auto", save
- [ ] Reopen the card in edit mode - Auto should still be checked
- [ ] Card should show gold "AUTO" badge below price badge