### PR TITLE
Simplify context menu animation

### DIFF
--- a/shared.css
+++ b/shared.css
@@ -969,14 +969,12 @@ select, input[type="text"] {
     z-index: 10000;
     opacity: 0;
     visibility: hidden;
-    transform: scale(0.95);
-    transition: all 0.15s ease;
+    transition: opacity 0.1s ease;
 }
 
 .card-context-menu.visible {
     opacity: 1;
     visibility: visible;
-    transform: scale(1);
 }
 
 .context-menu-item {


### PR DESCRIPTION
Remove scale transform, use simple fade (0.1s) for cleaner appearance.