### PR TITLE
Move super bowl badge to avoid auto badge overlap

### DIFF
--- a/washington-qbs-rookie-checklist.html
+++ b/washington-qbs-rookie-checklist.html
@@ -173,7 +173,7 @@
 
         .super-bowl-badge {
             position: absolute;
-            top: 8px;
+            bottom: 8px;
             left: 8px;
             background: linear-gradient(135deg, #f1c40f, #f39c12);
             color: #000;


### PR DESCRIPTION
Moved super bowl badge from top-left to bottom-left so it doesn't overlap with the auto badge.