### PR TITLE
Fix: trigger deploy after auto-merging image PRs

### DIFF
--- a/.github/workflows/auto-merge-images.yml
+++ b/.github/workflows/auto-merge-images.yml
@@ -11,6 +11,7 @@ on:
 permissions:
   contents: write
   pull-requests: write
+  actions: write
 
 jobs:
   auto-merge:
@@ -42,5 +43,11 @@ jobs:
       - name: Merge PR
         if: steps.check.outputs.should_merge == 'true'
         run: gh pr merge ${{ github.event.pull_request.number }} --squash --delete-branch
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Trigger deploy
+        if: steps.check.outputs.should_merge == 'true'
+        run: gh workflow run deploy.yml
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -3,6 +3,8 @@ name: Deploy to GitHub Pages
 on:
   push:
     branches: [main]
+  workflow_dispatch:
+  workflow_call:
 
 permissions:
   contents: read


### PR DESCRIPTION
## Problem
Image PRs merged via the auto-merge workflow didn't trigger deploys because `GITHUB_TOKEN` pushes don't trigger other workflows.

## Solution
- Add `workflow_dispatch` trigger to deploy workflow
- Have auto-merge workflow explicitly trigger deploy after merging

This ensures images are deployed immediately after merge.