### PR TITLE
Remove achievement badges from QB card display

### DIFF
--- a/washington-qbs-rookie-checklist.html
+++ b/washington-qbs-rookie-checklist.html
@@ -595,7 +595,6 @@
                     <div class="player-name">${card.player}</div>
                     <div class="player-years">${card.years} &bull; ${card.record}</div>
                     ${card.playoff !== '-' ? `<div class="player-record">Playoffs: ${card.playoff}</div>` : ''}
-                    ${CardRenderer.renderAchievements(card.achievement)}
                     <a href="${card.collectionLink}" class="collection-cta">View Full Collection →</a>
                 </div>`;
             }
@@ -617,7 +616,6 @@
                 <div class="card-info">
                     <span class="card-set">${card.set}</span> ${card.num}
                 </div>
-                ${CardRenderer.renderAchievements(card.achievement)}
                 <div class="card-actions${checklistManager.isReadOnly && !cardOwned ? ' links-only' : ''}">
                     ${!checklistManager.isReadOnly ? `<label class="checkbox-wrapper">
                         <input type="checkbox" id="${cardId}" ${cardOwned ? 'checked' : ''} onchange="toggleOwned('${cardId}')">


### PR DESCRIPTION
## Summary
- Remove achievement tag rendering from both featured player section and regular cards
- Achievement data is still stored in metadata for future use
- Reduces visual clutter on cards that had too many overlapping badges

## Test plan
- [ ] Visit Washington QBs checklist page
- [ ] Verify achievement badges no longer display on cards
- [ ] Confirm auto badge and price badge still show correctly