### PR TITLE
Fix scoreboard bounce on mobile (#267)

### DIFF
--- a/shared.css
+++ b/shared.css
@@ -477,7 +477,8 @@ h1 {
     padding: 16px 28px;
     border-radius: var(--radius-md);
     border: 1px solid rgba(255,255,255,0.08);
-    min-width: 100px;
+    min-width: 120px;
+    flex-shrink: 0;
 }
 
 .stat-value {
@@ -930,7 +931,10 @@ select, input[type="text"] {
 
     .stats { gap: 12px; }
 
-    .stat { padding: 12px 18px; }
+    .stat {
+        padding: 12px 18px;
+        min-width: 90px;
+    }
 
     .stat-value { font-size: 2em; }
 }


### PR DESCRIPTION
## Summary
- Increase stat box min-width to 120px (90px on mobile)
- Add `flex-shrink: 0` to prevent stat boxes from shrinking

This prevents layout reflow during the count-up animation when numbers change width, which was causing the page to bounce on mobile.

Closes #267

## Test plan
- [ ] Load a checklist page on mobile
- [ ] Watch the stats animate on page load
- [ ] Verify no page bouncing/reflow during animation