### PR TITLE
Fix JMU data migration and simplify editor subtitle

### DIFF
--- a/jmu-pro-players-checklist.html
+++ b/jmu-pro-players-checklist.html
@@ -275,18 +275,43 @@
 
         async function loadCardData() {
             // Try to load from gist first (gist is source of truth)
-            if (window.githubSync?.isLoggedIn()) {
+            // Migrate old tier-based categories to sport-based categories
+        function migrateCategories(data) {
+            if (!data?.categories) return data;
+            const cats = data.categories;
+            // Check if migration needed (old categories exist)
+            if (cats.hof || cats.probowl || cats.modern) {
+                const migrated = {
+                    NFL: [...(cats.hof || []), ...(cats.probowl || []), ...(cats.modern || [])],
+                    USFL: cats.usfl || [],
+                    MLB: cats.mlb || [],
+                    NBA: cats.nba || [],
+                    MLS: cats.mls || []
+                };
+                // Remove empty categories
+                Object.keys(migrated).forEach(k => { if (!migrated[k].length) delete migrated[k]; });
+                data.categories = migrated;
+                data.categoryDescriptions = { NFL: 'NFL Players', USFL: 'USFL Players', MLB: 'MLB Players', NBA: 'NBA Players', MLS: 'MLS Players' };
+            }
+            return data;
+        }
+
+        if (window.githubSync?.isLoggedIn()) {
                 const gistData = await githubSync.loadCardData('jmu-pro-players');
                 if (gistData) {
-                    checklistData = gistData;
+                    checklistData = migrateCategories(gistData);
                     cards = checklistData.categories;
+                    // Re-save if migrated
+                    if (gistData !== checklistData) {
+                        await githubSync.saveCardData('jmu-pro-players', checklistData);
+                    }
                     return;
                 }
             } else {
                 // Not logged in - try public gist for latest data
                 const publicData = await githubSync.loadPublicCardData('jmu-pro-players');
                 if (publicData) {
-                    checklistData = publicData;
+                    checklistData = migrateCategories(publicData);
                     cards = checklistData.categories;
                     return;
                 }

--- a/shared.js
+++ b/shared.js
@@ -1390,7 +1390,7 @@ class CardEditorModal {
 
         // Update title
         this.backdrop.querySelector('.card-editor-title').textContent = 'ADD NEW CARD';
-        this.backdrop.querySelector('.card-editor-subtitle').textContent = category ? `Adding to ${category}` : 'Create a new card';
+        this.backdrop.querySelector('.card-editor-subtitle').textContent = 'Enter card details';
         this.backdrop.querySelector('.card-editor-btn.save').textContent = 'Add Card';
         this.backdrop.querySelector('.card-editor-btn.delete').style.display = 'none';
 


### PR DESCRIPTION
## Summary
- Add migration function to convert old tier-based categories (hof, probowl, modern, etc.) to sport-based (NFL, USFL, etc.)
- Simplify editor subtitle from "Adding to [category]" to just "Enter card details"

## Test plan
- [ ] JMU page loads and shows cards (even if gist has old data)
- [ ] Add new card dialog shows simplified subtitle