### PR TITLE
Remove dead migration code (#274)

### DIFF
--- a/jmu-pro-players-checklist.html
+++ b/jmu-pro-players-checklist.html
@@ -275,43 +275,18 @@
 
         async function loadCardData() {
             // Try to load from gist first (gist is source of truth)
-            // Migrate old tier-based categories to sport-based categories
-        function migrateCategories(data) {
-            if (!data?.categories) return data;
-            const cats = data.categories;
-            // Check if migration needed (old categories exist)
-            if (cats.hof || cats.probowl || cats.modern) {
-                const migrated = {
-                    NFL: [...(cats.hof || []), ...(cats.probowl || []), ...(cats.modern || [])],
-                    USFL: cats.usfl || [],
-                    MLB: cats.mlb || [],
-                    NBA: cats.nba || [],
-                    MLS: cats.mls || []
-                };
-                // Remove empty categories
-                Object.keys(migrated).forEach(k => { if (!migrated[k].length) delete migrated[k]; });
-                data.categories = migrated;
-                data.categoryDescriptions = { NFL: 'NFL Players', USFL: 'USFL Players', MLB: 'MLB Players', NBA: 'NBA Players', MLS: 'MLS Players' };
-            }
-            return data;
-        }
-
-        if (window.githubSync?.isLoggedIn()) {
+            if (window.githubSync?.isLoggedIn()) {
                 const gistData = await githubSync.loadCardData('jmu-pro-players');
                 if (gistData) {
-                    checklistData = migrateCategories(gistData);
+                    checklistData = gistData;
                     cards = checklistData.categories;
-                    // Re-save if migrated
-                    if (gistData !== checklistData) {
-                        await githubSync.saveCardData('jmu-pro-players', checklistData);
-                    }
                     return;
                 }
             } else {
                 // Not logged in - try public gist for latest data
                 const publicData = await githubSync.loadPublicCardData('jmu-pro-players');
                 if (publicData) {
-                    checklistData = migrateCategories(publicData);
+                    checklistData = publicData;
                     cards = checklistData.categories;
                     return;
                 }

--- a/shared.js
+++ b/shared.js
@@ -779,9 +779,6 @@ class CardContextMenu {
     }
 }
 
-// Keep EditModeManager as alias for backward compatibility during transition
-const EditModeManager = CardContextMenu;
-
 /**
  * Image Processor - handles fetching, resizing, and converting images
  */
@@ -1591,7 +1588,6 @@ window.PriceUtils = PriceUtils;
 window.FilterUtils = FilterUtils;
 window.CardRenderer = CardRenderer;
 window.StatsAnimator = StatsAnimator;
-window.EditModeManager = EditModeManager;
 window.CardEditorModal = CardEditorModal;
 window.AddCardButton = AddCardButton;
 window.ImageProcessor = ImageProcessor;

--- a/washington-qbs-rookie-checklist.html
+++ b/washington-qbs-rookie-checklist.html
@@ -387,12 +387,6 @@
                 const gistData = await githubSync.loadCardData('washington-qbs');
                 if (gistData) {
                     checklistData = gistData;
-                    // Migrate legacy 'qbs' key to 'cards'
-                    if (checklistData.qbs && !checklistData.cards) {
-                        checklistData.cards = checklistData.qbs;
-                        delete checklistData.qbs;
-                        await githubSync.saveCardData('washington-qbs', checklistData);
-                    }
                     cards = checklistData.cards;
                     return;
                 }
@@ -401,8 +395,7 @@
                 const publicData = await githubSync.loadPublicCardData('washington-qbs');
                 if (publicData) {
                     checklistData = publicData;
-                    // Handle legacy 'qbs' key (can't migrate without login)
-                    cards = checklistData.cards || checklistData.qbs;
+                    cards = checklistData.cards;
                     return;
                 }
             }
@@ -432,7 +425,7 @@
             getStats: () => computeStats()
         });
 
-        // Wrapper functions for backward compatibility
+        // Helper functions
         function getCardId(card) {
             return btoa(card.player + card.set + card.num).replace(/[^a-zA-Z0-9]/g, '');
         }


### PR DESCRIPTION
## Summary
Removes migration code that has already served its purpose:

- **EditModeManager alias** - No longer used anywhere
- **Washington QBs 'qbs' to 'cards' migration** - Gist has been updated
- **JMU tier-to-sport category migration** - Gist has been updated
- Clean up misleading "backward compatibility" comment

**-41 lines** of dead code removed.

Closes #274

## Test plan
- [ ] Washington QBs page loads correctly
- [ ] JMU page loads correctly
- [ ] All three checklist pages still work