### PR TITLE
Fix deploy workflow to trigger on PR merge

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -3,6 +3,9 @@ name: Deploy to GitHub Pages
 on:
   push:
     branches: [main]
+  pull_request:
+    types: [closed]
+    branches: [main]
   workflow_dispatch:
   workflow_call:
 
@@ -18,6 +21,8 @@ concurrency:
 jobs:
   build:
     runs-on: ubuntu-latest
+    # Run on push, workflow_dispatch, or merged PRs (not just closed)
+    if: github.event_name != 'pull_request' || github.event.pull_request.merged == true
     steps:
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
## Summary
- Add `pull_request: closed` trigger as backup for when push events don't trigger the workflow
- Only runs on merged PRs, not just closed PRs
- Fixes issue where `gh pr merge` command doesn't trigger deploy workflow

## Test plan
- [ ] Merge this PR and verify deploy workflow runs