### PR TITLE
TEMPORARY: Add migration for gist name→variant field

### DIFF
--- a/jayden-daniels-rookie-checklist.html
+++ b/jayden-daniels-rookie-checklist.html
@@ -212,11 +212,34 @@
         let cards = null;
         let checklistData = null;
 
+        // TEMPORARY: Migrate gist data from 'name' to 'variant' field
+        // DELETE THIS FUNCTION after migration is complete
+        async function migrateNameToVariant(data) {
+            if (!data?.categories) return false;
+            let migrated = false;
+            for (const category of Object.values(data.categories)) {
+                for (const card of category) {
+                    if (card.name !== undefined && card.variant === undefined) {
+                        card.variant = card.name;
+                        delete card.name;
+                        migrated = true;
+                    }
+                }
+            }
+            if (migrated && window.githubSync?.isLoggedIn()) {
+                console.log('Migrating gist data: name → variant');
+                await githubSync.saveCardData('jayden-daniels', data);
+                console.log('Migration complete!');
+            }
+            return migrated;
+        }
+
         async function loadCardData() {
             // Try to load from gist first (gist is source of truth)
             if (window.githubSync?.isLoggedIn()) {
                 const gistData = await githubSync.loadCardData('jayden-daniels');
                 if (gistData) {
+                    await migrateNameToVariant(gistData); // TEMPORARY - delete after migration
                     checklistData = gistData;
                     cards = checklistData.categories;
                     return;

--- a/jmu-pro-players-checklist.html
+++ b/jmu-pro-players-checklist.html
@@ -273,11 +273,34 @@
         let cards = null;
         let checklistData = null;
 
+        // TEMPORARY: Migrate gist data from 'name' to 'variant' field
+        // DELETE THIS FUNCTION after migration is complete
+        async function migrateNameToVariant(data) {
+            if (!data?.categories) return false;
+            let migrated = false;
+            for (const category of Object.values(data.categories)) {
+                for (const card of category) {
+                    if (card.name !== undefined && card.variant === undefined) {
+                        card.variant = card.name;
+                        delete card.name;
+                        migrated = true;
+                    }
+                }
+            }
+            if (migrated && window.githubSync?.isLoggedIn()) {
+                console.log('Migrating gist data: name → variant');
+                await githubSync.saveCardData('jmu-pro-players', data);
+                console.log('Migration complete!');
+            }
+            return migrated;
+        }
+
         async function loadCardData() {
             // Try to load from gist first (gist is source of truth)
             if (window.githubSync?.isLoggedIn()) {
                 const gistData = await githubSync.loadCardData('jmu-pro-players');
                 if (gistData) {
+                    await migrateNameToVariant(gistData); // TEMPORARY - delete after migration
                     checklistData = gistData;
                     cards = checklistData.categories;
                     return;


### PR DESCRIPTION
## Summary
- Adds one-time migration that renames `name` to `variant` in gist card data
- Runs automatically when loading each checklist page while logged in
- Check browser console for "Migration complete!" message

## Test plan
1. [ ] Load jayden-daniels-rookie-checklist.html while logged in
2. [ ] Check console for migration message
3. [ ] Verify owned cards show correctly
4. [ ] Load jmu-pro-players-checklist.html while logged in
5. [ ] Check console for migration message
6. [ ] Verify owned cards show correctly

## After verification
Delete the `migrateNameToVariant` function and its call from both files.