### PR TITLE
Fix JMU categories not loading on index page

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ The site supports Cloudflare Pages preview deployments for testing:
 ## Tech Stack
 
 - **Frontend**: Vanilla JavaScript (no frameworks)
-- **Hosting**: GitHub Pages
+- **Hosting**: GitHub Pages (production), Cloudflare Pages (preview)
 - **Auth**: GitHub OAuth via Cloudflare Workers
 - **Storage**: GitHub Gists (JSON)
 - **Images**: WebP format, processed client-side

--- a/index.html
+++ b/index.html
@@ -602,7 +602,7 @@
 
             if (checklistId === 'jmu-pro-players') {
                 const cats = cardData.categories;
-                const allCards = [...(cats.hof || []), ...(cats.probowl || []), ...(cats.usfl || []), ...(cats.modern || []), ...(cats.mlb || []), ...(cats.nba || []), ...(cats.mls || [])];
+                const allCards = [...(cats.NFL || []), ...(cats.USFL || []), ...(cats.MLB || []), ...(cats.NBA || []), ...(cats.MLS || [])];
                 // Separate main cards from alternates
                 const mainCards = allCards.filter(c => !c.alternate);
                 const alternates = allCards.filter(c => c.alternate);


### PR DESCRIPTION
## Summary
- Fix JMU card data not displaying on index page
- Category names were mismatched (expected hof/probowl/etc, actual is NFL/USFL/MLB/NBA/MLS)
- Also adds Cloudflare Pages to tech stack in README

Closes #236

## Test plan
- [x] Verify JMU stats now show on index page