### PR TITLE
Fix deploy workflow missing checkout step

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -25,6 +25,8 @@ jobs:
     if: github.event_name == 'pull_request' && github.event.pull_request.merged == true
     runs-on: ubuntu-latest
     steps:
+      - name: Checkout
+        uses: actions/checkout@v4
       - name: Trigger deploy workflow on main
         run: gh workflow run deploy.yml --ref main
         env:


### PR DESCRIPTION
## Summary
The trigger-deploy job was failing with `fatal: not a git repository` because `gh` CLI needs a git repo context.

Added checkout step before running gh workflow command.

## Test plan
- [x] Verify PR merge triggers successful deploy