### PR TITLE
Simplify preview deployment docs in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,21 +93,9 @@ Then open http://localhost:8000
 
 ### Preview Deployments
 
-The site supports Cloudflare Pages preview deployments for testing changes without affecting production data.
-
-**URLs:**
-- Production: `iammike.github.io/sports-card-checklists`
-- Preview (main): `sports-card-checklists.pages.dev`
-- Preview (branch): `<branch>.sports-card-checklists.pages.dev`
-
-**Gist Isolation:**
-- Preview sites use a separate gist so test changes don't affect production
-- "Sync from Production" button copies live data to preview for testing
-- Detection based on `.pages.dev` hostname
-
-**Worker Environment Variables:**
-- `GITHUB_CLIENT_ID` / `GITHUB_CLIENT_SECRET` - Production OAuth app
-- `GITHUB_CLIENT_ID_PREVIEW` / `GITHUB_CLIENT_SECRET_PREVIEW` - Preview OAuth app
+Cloudflare Pages preview deployments allow testing changes without affecting production:
+- Branch previews at `<branch>.sports-card-checklists.pages.dev`
+- Isolated data storage (changes don't affect production)
 
 ### Project Structure
 ```


### PR DESCRIPTION
Remove implementation details, keep it concise.