### PR TITLE
Sort cards alphabetically after adding

### DIFF
--- a/scripts/add-cards.js
+++ b/scripts/add-cards.js
@@ -268,6 +268,8 @@ async function main() {
         }
 
         checklistData.categories[category].push(card);
+        // Sort by set name alphabetically
+        checklistData.categories[category].sort((a, b) => a.set.localeCompare(b.set));
         console.log(`  Added: ${card.set} ${card.num} -> ${category}`);
     }
 


### PR DESCRIPTION
## Summary
- Sort cards by set name after adding to keep categories organized

## Test plan
- [ ] Run add-cards.js with --dry-run and verify cards are sorted