### PR TITLE
Rename 'chase' category to 'premium'

### DIFF
--- a/index.html
+++ b/index.html
@@ -443,7 +443,7 @@
                         </div>
                         <div class="secondary-stats">
                             <span class="stat-pill">Inserts <span class="count" id="stat-inserts-jayden-daniels">0/0</span></span>
-                            <span class="stat-pill">Chase <span class="count" id="stat-chase-jayden-daniels">0/0</span></span>
+                            <span class="stat-pill">Premium <span class="count" id="stat-premium-jayden-daniels">0/0</span></span>
                         </div>
                     </div>
                 </div>
@@ -548,7 +548,7 @@
                 const cats = cardData.categories;
                 const baseCards = [...(cats.college || []), ...(cats.panini || []), ...(cats.topps || []), ...(cats.other || [])];
                 const inserts = cats.inserts || [];
-                const chase = cats.chase || [];
+                const premium = cats.premium || [];
 
                 let baseOwned = 0, baseValue = 0, baseOwnedValue = 0;
                 baseCards.forEach(c => {
@@ -563,8 +563,8 @@
                 let insertsOwned = 0;
                 inserts.forEach(c => { if (owned.has(getCardId(c))) insertsOwned++; });
 
-                let chaseOwned = 0;
-                chase.forEach(c => { if (owned.has(getCardId(c))) chaseOwned++; });
+                let premiumOwned = 0;
+                premium.forEach(c => { if (owned.has(getCardId(c))) premiumOwned++; });
 
                 return {
                     owned: baseOwned,
@@ -572,7 +572,7 @@
                     ownedValue: Math.round(baseOwnedValue),
                     neededValue: Math.round(baseValue - baseOwnedValue),
                     insertsOwned, insertsTotal: inserts.length,
-                    chaseOwned, chaseTotal: chase.length
+                    premiumOwned, premiumTotal: premium.length
                 };
             }
 
@@ -678,8 +678,8 @@
             if (jdStats) {
                 const insertsEl = document.getElementById('stat-inserts-jayden-daniels');
                 if (insertsEl) insertsEl.textContent = `${jdStats.insertsOwned || 0}/${jdStats.insertsTotal || 0}`;
-                const chaseEl = document.getElementById('stat-chase-jayden-daniels');
-                if (chaseEl) chaseEl.textContent = `${jdStats.chaseOwned || 0}/${jdStats.chaseTotal || 0}`;
+                const premiumEl = document.getElementById('stat-premium-jayden-daniels');
+                if (premiumEl) premiumEl.textContent = `${jdStats.premiumOwned || 0}/${jdStats.premiumTotal || 0}`;
             }
 
             // Washington QBs

--- a/jayden-daniels-rookie-checklist.html
+++ b/jayden-daniels-rookie-checklist.html
@@ -54,27 +54,27 @@
             border-bottom: 1px solid rgba(243, 156, 18, 0.2);
         }
 
-        /* Chase section */
-        .section-header.chase {
+        /* Premium section */
+        .section-header.premium {
             background: linear-gradient(135deg, #f39c12 0%, #e74c3c 100%);
             cursor: pointer;
             user-select: none;
         }
-        .section-header.chase::after {
+        .section-header.premium::after {
             content: ' ▼';
             font-size: 12px;
             opacity: 0.7;
         }
-        .section-header.chase.collapsed::after {
+        .section-header.premium.collapsed::after {
             content: ' ▶';
         }
-        .chase-section .card-grid {
+        .premium-section .card-grid {
             display: none;
         }
-        .chase-section.expanded .card-grid {
+        .premium-section.expanded .card-grid {
             display: grid;
         }
-        .chase-note {
+        .premium-note {
             background: rgba(243, 156, 18, 0.1);
             color: #b36b00;
             padding: 10px 15px;
@@ -197,10 +197,10 @@
     </div>
 
     <!-- CHASE CARDS (expensive/rare) -->
-    <div class="section chase-section expanded" id="chase-section">
-        <div class="section-header chase" onclick="toggleChaseSection()">Chase Cards (SSP/Case Hits)</div>
-        <div class="chase-note">Rare SSPs and premium product cards ($50+). Not included in main checklist totals.</div>
-        <div class="card-grid" id="chase-cards"></div>
+    <div class="section premium-section expanded" id="premium-section">
+        <div class="section-header premium" onclick="togglePremiumSection()">Premium Cards (SSP/Case Hits)</div>
+        <div class="premium-note">Rare SSPs and premium product cards ($50+). Not included in main checklist totals.</div>
+        <div class="card-grid" id="premium-cards"></div>
     </div>
 
     </div><!-- end page-content -->
@@ -273,7 +273,7 @@
                 }
             });
             const ownedInserts = cards.inserts.filter(c => isOwned(getCardId(c))).length;
-            const ownedChase = cards.chase.filter(c => isOwned(getCardId(c))).length;
+            const ownedPremium = cards.premium.filter(c => isOwned(getCardId(c))).length;
 
             return {
                 owned: ownedVisible,
@@ -282,8 +282,8 @@
                 neededValue: Math.round(neededValue),
                 insertsOwned: ownedInserts,
                 insertsTotal: cards.inserts.length,
-                chaseOwned: ownedChase,
-                chaseTotal: cards.chase.length
+                premiumOwned: ownedPremium,
+                premiumTotal: cards.premium.length
             };
         }
 
@@ -301,8 +301,8 @@
             // Stats are now saved atomically with owned cards via getStats callback
         }
 
-        function toggleChaseSection() {
-            const section = document.getElementById('chase-section');
+        function togglePremiumSection() {
+            const section = document.getElementById('premium-section');
             const header = section.querySelector('.section-header');
             section.classList.toggle('expanded');
             header.classList.toggle('collapsed');
@@ -425,8 +425,8 @@
                 const sorted = sortCards(allCards, sortBy);
                 document.getElementById('sorted-cards').innerHTML = sorted.map(createCardElement).join('');
             }
-            // Always render chase cards (separate from sorting)
-            document.getElementById('chase-cards').innerHTML = cards.chase.map(createCardElement).join('');
+            // Always render premium cards (separate from sorting)
+            document.getElementById('premium-cards').innerHTML = cards.premium.map(createCardElement).join('');
             updateStats();
         }
 
@@ -456,7 +456,7 @@
                 variant: { label: 'Card Variant', type: 'text', placeholder: 'Silver Prizm /199', fullWidth: true }
             },
             imageFolder: 'jayden-daniels-cards',
-            categories: ['college', 'panini', 'topps', 'other', 'inserts', 'chase'],
+            categories: ['college', 'panini', 'topps', 'other', 'inserts', 'premium'],
             onSave: async (cardId, cardData, isNew) => {
                 if (isNew) {
                     // Add new card to appropriate category

--- a/scripts/add-cards.js
+++ b/scripts/add-cards.js
@@ -41,7 +41,7 @@ const CHECKLIST_FILES = {
     'jmu-pro-players': 'jmu-pro-players-cards.json'
 };
 
-const VALID_CATEGORIES = ['college', 'panini', 'topps', 'other', 'inserts', 'chase'];
+const VALID_CATEGORIES = ['college', 'panini', 'topps', 'other', 'inserts', 'premium'];
 
 function printUsage() {
     console.log(`

--- a/shared.css
+++ b/shared.css
@@ -891,7 +891,7 @@ select, input[type="text"] {
 }
 
 /* ============================================
-   Notes (for inserts, chase, extras)
+   Notes (for inserts, premium, extras)
    ============================================ */
 .section-note {
     font-family: 'Barlow', sans-serif;

--- a/shared.js
+++ b/shared.js
@@ -1117,7 +1117,7 @@ class CardEditorModal {
         this.onSave = options.onSave || (() => {});
         this.onDelete = options.onDelete || (() => {});
         this.cardTypes = options.cardTypes || CARD_TYPES;
-        this.categories = options.categories || null; // e.g., ['panini', 'topps', 'inserts', 'chase']
+        this.categories = options.categories || null; // e.g., ['panini', 'topps', 'inserts', 'premium']
         this.imageFolder = options.imageFolder || 'images'; // folder for processed images
         this.currentCard = null;
         this.currentCardId = null;


### PR DESCRIPTION
## Summary
Renames the 'chase' category to 'premium' to better reflect that it includes both:
- SSP/case hit inserts (Kaboom, Downtown, Color Blast)
- Premium product cards (National Treasures, Immaculate, Flawless)

## Changes
- Renamed CSS classes (.chase-section → .premium-section, etc.)
- Updated section IDs and onclick handlers
- Updated card editor dropdown options
- Updated CLI add-cards.js valid categories
- Updated gist data (category key renamed)

Closes #313

## Test plan
- [ ] Verify premium section displays correctly on JD checklist page
- [ ] Verify premium stat pill shows on index page
- [ ] Verify adding cards to premium category via CLI works
- [ ] Verify editing cards shows "Premium" in category dropdown