### PR TITLE
Add image editor with crop and rotate

### DIFF
--- a/shared.css
+++ b/shared.css
@@ -1546,3 +1546,206 @@ select, input[type="text"] {
         font-size: 13px;
     }
 }
+
+/* ============================================
+   Image Editor Modal (crop/rotate)
+   ============================================ */
+.image-editor-backdrop {
+    position: fixed;
+    inset: 0;
+    background: rgba(0, 0, 0, 0.85);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    z-index: 10000;
+    opacity: 0;
+    visibility: hidden;
+    transition: opacity 0.2s ease, visibility 0.2s ease;
+}
+
+.image-editor-backdrop.active {
+    opacity: 1;
+    visibility: visible;
+}
+
+.image-editor-modal {
+    background: #1a1a2e;
+    border-radius: 12px;
+    width: 90vw;
+    max-width: 900px;
+    max-height: 90vh;
+    display: flex;
+    flex-direction: column;
+    box-shadow: 0 20px 60px rgba(0, 0, 0, 0.5);
+    transform: scale(0.9);
+    transition: transform 0.2s ease;
+}
+
+.image-editor-backdrop.active .image-editor-modal {
+    transform: scale(1);
+}
+
+.image-editor-header {
+    padding: 20px 24px;
+    border-bottom: 1px solid rgba(255, 255, 255, 0.1);
+    position: relative;
+}
+
+.image-editor-title {
+    margin: 0;
+    font-family: 'Bebas Neue', sans-serif;
+    font-size: 24px;
+    letter-spacing: 0.1em;
+    color: white;
+}
+
+.image-editor-subtitle {
+    font-size: 13px;
+    color: rgba(255, 255, 255, 0.5);
+    margin-top: 4px;
+}
+
+.image-editor-close {
+    position: absolute;
+    top: 16px;
+    right: 16px;
+    background: none;
+    border: none;
+    color: rgba(255, 255, 255, 0.5);
+    font-size: 28px;
+    cursor: pointer;
+    line-height: 1;
+    padding: 4px 8px;
+}
+
+.image-editor-close:hover {
+    color: white;
+}
+
+.image-editor-body {
+    flex: 1;
+    min-height: 0;
+    display: flex;
+    flex-direction: column;
+    padding: 16px;
+}
+
+.image-editor-canvas {
+    flex: 1;
+    min-height: 300px;
+    max-height: 60vh;
+    background: #0d0d1a;
+    border-radius: 8px;
+    overflow: hidden;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+}
+
+.image-editor-canvas img {
+    max-width: 100%;
+    max-height: 100%;
+    display: block;
+}
+
+.image-editor-toolbar {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 8px;
+    padding: 16px 0 8px;
+}
+
+.image-editor-tool {
+    width: 44px;
+    height: 44px;
+    border-radius: 8px;
+    border: 1px solid rgba(255, 255, 255, 0.2);
+    background: rgba(255, 255, 255, 0.05);
+    color: rgba(255, 255, 255, 0.8);
+    cursor: pointer;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    transition: all 0.15s ease;
+}
+
+.image-editor-tool svg {
+    width: 22px;
+    height: 22px;
+}
+
+.image-editor-tool:hover {
+    background: rgba(255, 255, 255, 0.15);
+    color: white;
+    border-color: rgba(255, 255, 255, 0.4);
+}
+
+.image-editor-tool:active {
+    transform: scale(0.95);
+}
+
+.image-editor-divider {
+    width: 1px;
+    height: 28px;
+    background: rgba(255, 255, 255, 0.15);
+    margin: 0 8px;
+}
+
+.image-editor-footer {
+    padding: 16px 24px 20px;
+    border-top: 1px solid rgba(255, 255, 255, 0.1);
+    display: flex;
+    justify-content: flex-end;
+    gap: 12px;
+}
+
+.image-editor-btn {
+    padding: 12px 24px;
+    border-radius: 6px;
+    font-family: 'Barlow', sans-serif;
+    font-size: 14px;
+    font-weight: 600;
+    cursor: pointer;
+    transition: all 0.15s ease;
+}
+
+.image-editor-btn.cancel {
+    background: transparent;
+    border: 1px solid rgba(255, 255, 255, 0.2);
+    color: rgba(255, 255, 255, 0.7);
+}
+
+.image-editor-btn.cancel:hover {
+    background: rgba(255, 255, 255, 0.1);
+    color: white;
+}
+
+.image-editor-btn.confirm {
+    background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+    border: none;
+    color: white;
+}
+
+.image-editor-btn.confirm:hover {
+    filter: brightness(1.1);
+}
+
+@media (max-width: 600px) {
+    .image-editor-modal {
+        width: 100vw;
+        height: 100vh;
+        max-width: none;
+        max-height: none;
+        border-radius: 0;
+    }
+
+    .image-editor-canvas {
+        max-height: none;
+        flex: 1;
+    }
+
+    .image-editor-toolbar {
+        flex-wrap: wrap;
+    }
+}


### PR DESCRIPTION
## Summary
Adds an in-browser image editor that appears when processing images. Users can crop, rotate, and flip images before they're processed and committed.

## Features
- **Crop**: Drag crop handles to focus on the card, removing eBay watermarks and backgrounds
- **Rotate**: 90° left/right rotation for sideways images
- **Flip**: Horizontal and vertical flip
- **Reset**: Return to original image

## Implementation
- Uses Cropper.js (loaded from CDN on first use)
- New `ImageEditorModal` class handles the editing UI
- Modified `processImage` and `processLocalFile` to show editor before final processing
- Dark modal theme matching the card editor

Closes #254

## Test plan
- [ ] Click Process on eBay URL - editor should appear with crop handles
- [ ] Rotate image 90° - verify rotation applies
- [ ] Crop to remove watermarks - verify cropped area is preserved
- [ ] Click Cancel - verify original URL is preserved, no commit made
- [ ] Upload local file - editor should appear
- [ ] After confirming, image should be processed and committed as before