### PR TITLE
Fix image editor hanging when cropper not initialized

### DIFF
--- a/shared.js
+++ b/shared.js
@@ -1295,7 +1295,14 @@ class ImageEditorModal {
 
     // Confirm - return cropped/edited image
     confirm() {
-        if (!this.cropper) return;
+        if (!this.cropper) {
+            // Cropper not initialized - reject with error
+            this.close();
+            if (this.rejectPromise) {
+                this.rejectPromise(new Error('Image editor not ready'));
+            }
+            return;
+        }
 
         try {
             // Get cropped canvas
@@ -1303,6 +1310,10 @@ class ImageEditorModal {
                 maxWidth: 1200,
                 maxHeight: 1200,
             });
+
+            if (!canvas) {
+                throw new Error('Failed to get cropped image');
+            }
 
             // Convert to data URL
             const dataUrl = canvas.toDataURL('image/png');
@@ -1312,6 +1323,7 @@ class ImageEditorModal {
                 this.resolvePromise(dataUrl);
             }
         } catch (error) {
+            this.close();
             if (this.rejectPromise) {
                 this.rejectPromise(error);
             }


### PR DESCRIPTION
## Bug Fix
The image editor confirm() method would silently return without resolving or rejecting the promise if the cropper wasn't initialized, causing the Process button to spin forever.

## Changes
- Now properly rejects the promise with an error message if cropper is null
- Added check for null canvas from getCroppedCanvas
- Ensures close() is called even on error

## Test plan
- [ ] Click Process on an image URL - should show editor or error, never hang