### PR TITLE
Fix: Allow clearing variant field to empty

### DIFF
--- a/jayden-daniels-rookie-checklist.html
+++ b/jayden-daniels-rookie-checklist.html
@@ -493,6 +493,7 @@
                         if (!('img' in cardData)) delete card.img;
                         if (!('achievement' in cardData)) delete card.achievement;
                         if (!('auto' in cardData)) delete card.auto;
+                        if (!cardData.variant) delete card.variant;
                         // Remove from old category
                         cards[oldCategory].splice(index, 1);
                         // Insert into (possibly new) category

--- a/shared.js
+++ b/shared.js
@@ -1530,13 +1530,12 @@ class CardEditorModal {
                 data[fieldName] = el.value;
             } else {
                 const val = el.value.trim();
-                if (val) {
-                    // Parse comma-separated values if configured
-                    if (config.parseArray) {
-                        data[fieldName] = val.split(',').map(v => v.trim()).filter(v => v);
-                    } else {
-                        data[fieldName] = val;
-                    }
+                // Parse comma-separated values if configured
+                if (config.parseArray) {
+                    data[fieldName] = val ? val.split(',').map(v => v.trim()).filter(v => v) : [];
+                } else {
+                    // Always include the value (even empty string) so calling code can clear fields
+                    data[fieldName] = val;
                 }
             }
         }


### PR DESCRIPTION
## Summary
- `getCustomFieldData()` now includes empty strings for text fields (was skipping them)
- Jayden Daniels page now deletes variant field when cleared to empty

Fixes #343

## Test plan
- [ ] Edit a card with an existing variant
- [ ] Clear the variant field to empty
- [ ] Save - variant should be removed from the card