### PR TITLE
Add note about Cloudflare preview URL truncation

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -12,6 +12,7 @@
 - GitHub Pages deploys in ~30-60 seconds after push
 - After a PR is merged, wait for user to test before pushing more fixes - create new PRs instead of adding to old branches
 - **Preview gist sync** - Before testing on Cloudflare preview sites, remind user to sync preview gist from production (login on preview site, use "Sync from Production" button). Otherwise data may be stale or have outdated schema.
+- **Preview URL truncation** - Cloudflare Pages truncates long branch names in preview URLs (e.g., `experiment-simplify-card-typ.sports-card-checklists.pages.dev`). Keep branch names short or check Cloudflare dashboard for exact URL.
 
 ## Consistency
 - When making changes to a page or card component, consider applying the same change to all checklists/cards


### PR DESCRIPTION
Documents that Cloudflare Pages truncates long branch names in preview URLs.