### PR TITLE
Add rule to avoid print-on-demand cards

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -1,5 +1,8 @@
 # Sports Card Checklists Project
 
+## Card Selection
+- **Avoid print-on-demand cards** - Do not add Topps Now or Panini Instant cards. These are made-to-order products, not traditional trading cards.
+
 ## Data Storage
 - **The GitHub Gist is the source of truth** for all collection data (owned cards, stats)
 - Never use localStorage as the primary data source - it won't work for online visitors


### PR DESCRIPTION
Topps Now and Panini Instant are print-on-demand products - don't add them to checklists.