### PR TITLE
Fix: Regenerate search term when eBay field is cleared

### DIFF
--- a/shared.js
+++ b/shared.js
@@ -2146,8 +2146,8 @@ class CardEditorModal {
             }
         }
 
-        // For new cards without an eBay search term, auto-generate one
-        if (this.isNewCard && !data.ebay) {
+        // Auto-generate search term if ebay field is empty
+        if (!data.ebay) {
             data.search = this.generateSearchTerm(data.set, data.num, data.variant);
         }
 


### PR DESCRIPTION
## Summary
Clearing the eBay search term field now regenerates the search term from card data.

Fixes #348

## Test plan
- [ ] Edit existing card with a search term
- [ ] Clear the eBay field
- [ ] Save - search term should regenerate from set/num/variant