### PR TITLE
Fix: Allow clearing image field

### DIFF
--- a/shared.js
+++ b/shared.js
@@ -2042,9 +2042,14 @@ class CardEditorModal {
         const data = {
             set: this.backdrop.querySelector('#editor-set').value.trim(),
             num: num,
-            type: this.backdrop.querySelector('#editor-type').value,
-            img: this.backdrop.querySelector('#editor-img').value.trim()
+            type: this.backdrop.querySelector('#editor-type').value
         };
+
+        // Image - only include if set (so clearing can delete it)
+        const imgVal = this.backdrop.querySelector('#editor-img').value.trim();
+        if (imgVal) {
+            data.img = imgVal;
+        }
 
         // Category - only include if field exists
         const categoryField = this.backdrop.querySelector('#editor-category');


### PR DESCRIPTION
## Summary
The `img` field was always included in form data, even when empty. This meant clearing the image field never actually deleted it from the card data.

Now `img` is only included if it has a value, allowing it to be properly cleared.

## Test plan
- [ ] Edit card with an image
- [ ] Clear the image field
- [ ] Save - image should be removed from card