### PR TITLE
Add +/- buttons for fine rotation control

### DIFF
--- a/shared.css
+++ b/shared.css
@@ -1790,6 +1790,30 @@ select, input[type="text"] {
     font-variant-numeric: tabular-nums;
 }
 
+.image-editor-step-btn {
+    width: 24px;
+    height: 24px;
+    border: none;
+    border-radius: 4px;
+    background: rgba(255, 255, 255, 0.15);
+    color: white;
+    font-size: 16px;
+    font-weight: bold;
+    cursor: pointer;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    transition: background 0.15s;
+}
+
+.image-editor-step-btn:hover {
+    background: rgba(255, 255, 255, 0.25);
+}
+
+.image-editor-step-btn:active {
+    background: rgba(255, 255, 255, 0.35);
+}
+
 @media (max-width: 600px) {
     .image-editor-modal {
         width: 100vw;

--- a/shared.js
+++ b/shared.js
@@ -1187,7 +1187,9 @@ class ImageEditorModal {
                     <div class="image-editor-sliders">
                         <div class="image-editor-slider-row">
                             <label class="image-editor-slider-label">Straighten</label>
+                            <button class="image-editor-step-btn" id="rotate-minus" title="Decrease 1°">−</button>
                             <input type="range" class="image-editor-slider" id="image-editor-rotate" min="-45" max="45" value="0" step="0.5">
+                            <button class="image-editor-step-btn" id="rotate-plus" title="Increase 1°">+</button>
                             <span class="image-editor-slider-value" id="image-editor-rotate-value">0°</span>
                         </div>
                     </div>
@@ -1243,6 +1245,16 @@ class ImageEditorModal {
                 rotateValue.textContent = '0°';
                 if (this.cropper) this.cropper.rotateTo(0);
             };
+
+            // +/- buttons for fine adjustment
+            const updateRotation = (delta) => {
+                const newVal = Math.max(-45, Math.min(45, parseFloat(rotateSlider.value) + delta));
+                rotateSlider.value = newVal;
+                rotateValue.textContent = `${newVal}°`;
+                if (this.cropper) this.cropper.rotateTo(newVal);
+            };
+            this.backdrop.querySelector('#rotate-minus').onclick = () => updateRotation(-1);
+            this.backdrop.querySelector('#rotate-plus').onclick = () => updateRotation(1);
         }
 
         // Escape key to close


### PR DESCRIPTION
## Summary
Add minus and plus buttons flanking the rotation slider for precise 1° adjustments.

Fixes #337

## Test plan
- [ ] Open image editor
- [ ] Click + button - rotation increases by 1°
- [ ] Click - button - rotation decreases by 1°
- [ ] Buttons respect -45/+45 limits