### PR TITLE
Rename college section to be year-agnostic

### DIFF
--- a/jayden-daniels-rookie-checklist.html
+++ b/jayden-daniels-rookie-checklist.html
@@ -111,7 +111,7 @@
     <div class="page-header">
 
         <h1>Jayden Daniels Rookie Card Checklist</h1>
-        <p class="subtitle">2023 College + 2024 NFL Rookie Cards</p>
+        <p class="subtitle">College + NFL Rookie Cards</p>
         <div class="stats">
             <div class="stat">
                 <div class="stat-value" id="owned-count">0</div>
@@ -159,7 +159,7 @@
 
     <!-- COLLEGE CARDS -->
     <div class="section default-section">
-        <div class="section-header college">2023 College Cards (LSU - Heisman Year)</div>
+        <div class="section-header college">College Cards (Leaf, Sage, Unlicensed)</div>
         <div class="card-grid" id="college-cards"></div>
     </div>
 


### PR DESCRIPTION
## Summary
- Section header: "College Cards (Leaf, Sage, Unlicensed)"
- Subtitle: "College + NFL Rookie Cards"

## Manual step required
After merging, move these cards from "other"/"inserts" to "college" via the card editor:

**From "other" → "college":**
- 2024 Leaf Metal #90B-3
- 2024 Leaf Trinity #53
- 2024 SAGE Artistry #59
- 2024 SAGE Hit #122
- 2024 SAGE Hit Low Series #16
- 2024 SAGE Next Level #91

**From "inserts" → "college":**
- 2024 Leaf Hype #147
- 2024 Leaf Hype #R-147A