### PR TITLE
Remove year from section headers

### DIFF
--- a/jayden-daniels-rookie-checklist.html
+++ b/jayden-daniels-rookie-checklist.html
@@ -163,8 +163,8 @@
         <div class="card-grid" id="college-cards"></div>
     </div>
 
-    <!-- BASE CARDS 2024 -->
-    <div class="group-header">2024 Base Rookie Cards</div>
+    <!-- BASE CARDS -->
+    <div class="group-header">Base Rookie Cards</div>
     <div class="section-group">
         <!-- PANINI 2024 -->
         <div class="section default-section">
@@ -187,7 +187,7 @@
 
     <!-- INSERTS 2024 -->
     <div class="section inserts-section expanded" id="inserts-section">
-        <div class="group-header inserts" style="background: linear-gradient(135deg, #f093fb 0%, #f5576c 100%); cursor: pointer;" onclick="toggleInsertsSection()">2024 Inserts</div>
+        <div class="group-header inserts" style="background: linear-gradient(135deg, #f093fb 0%, #f5576c 100%); cursor: pointer;" onclick="toggleInsertsSection()">Inserts</div>
         <div class="inserts-note">Optional insert cards. Not included in main checklist totals.</div>
         <div class="section-group">
             <div class="section default-section">


### PR DESCRIPTION
Remove '2024' from 'Base Rookie Cards' and 'Inserts' headers for consistency with other sections.