### PR TITLE
Add Edit button for existing local images

### DIFF
--- a/shared.css
+++ b/shared.css
@@ -1384,6 +1384,55 @@ select, input[type="text"] {
     to { transform: rotate(360deg); }
 }
 
+/* Edit button - for editing existing local images */
+.card-editor-edit-btn {
+    display: none;
+    align-items: center;
+    justify-content: center;
+    padding: 0 16px;
+    background: linear-gradient(135deg, #43e97b 0%, #38f9d7 100%);
+    border: none;
+    border-radius: 4px;
+    color: #1a1a2e;
+    font-family: 'Barlow', sans-serif;
+    font-size: 12px;
+    font-weight: 600;
+    letter-spacing: 0.04em;
+    cursor: pointer;
+    transition: all 0.2s;
+    white-space: nowrap;
+    min-width: 60px;
+}
+
+.card-editor-edit-btn:hover {
+    transform: translateY(-1px);
+    box-shadow: 0 4px 12px rgba(67, 233, 123, 0.4);
+}
+
+.card-editor-edit-btn:disabled {
+    opacity: 0.7;
+    cursor: not-allowed;
+    transform: none;
+}
+
+.card-editor-edit-btn .edit-spinner {
+    display: none;
+    width: 14px;
+    height: 14px;
+    border: 2px solid rgba(26, 26, 46, 0.3);
+    border-top-color: #1a1a2e;
+    border-radius: 50%;
+    animation: processSpinner 0.8s linear infinite;
+}
+
+.card-editor-edit-btn.processing .edit-text {
+    display: none;
+}
+
+.card-editor-edit-btn.processing .edit-spinner {
+    display: block;
+}
+
 .card-editor-image-preview {
     width: 100%;
     height: 180px;


### PR DESCRIPTION
## Summary
- Adds an Edit button to the card editor that appears when viewing cards with local images
- Clicking Edit opens the image in the image editor for rotation/cropping adjustments
- Edited images are saved with a timestamp suffix and committed via PR

Closes #327

## Test plan
- [ ] Open card editor for a card with a local image (e.g., in `images/` folder)
- [ ] Verify Edit button appears next to Process button
- [ ] Click Edit and make changes in the image editor
- [ ] Verify new image is committed via PR with timestamp suffix
- [ ] Verify card editor updates with new image path