### PR TITLE
Fix image preview for local paths

### DIFF
--- a/shared.js
+++ b/shared.js
@@ -1755,7 +1755,8 @@ class CardEditorModal {
     // Update image preview
     updateImagePreview(url) {
         const preview = this.backdrop.querySelector('.card-editor-image-preview');
-        if (url && (url.startsWith('http') || url.startsWith('/') || url.startsWith('data:'))) {
+        if (url) {
+            // Handle data URLs, absolute URLs, and relative paths (like jayden-daniels-cards/img.webp)
             const src = url.startsWith('data:') ? url : sanitizeUrl(url);
             preview.innerHTML = `<img src="${src}" alt="Preview" onerror="this.outerHTML='<span class=\\'placeholder\\'>Failed to load</span>'">`;
         } else {


### PR DESCRIPTION
## Summary
- Card editor now shows image preview for cards with local/relative image paths
- Previously only showed preview for URLs starting with `http`, `/`, or `data:`
- Local images like `jayden-daniels-cards/img.webp` were being ignored

## Test plan
- [ ] Open card editor for a card with a local image
- [ ] Verify the image preview shows the actual image
- [ ] Verify Edit button appears next to the image