### PR TITLE
Improve error handling for image edit/commit

### DIFF
--- a/github-sync.js
+++ b/github-sync.js
@@ -592,7 +592,11 @@ class GitHubSync {
                     })
                 }
             );
-            if (!commitImage.ok) throw new Error('Failed to commit image');
+            if (!commitImage.ok) {
+                const errorData = await commitImage.json().catch(() => ({}));
+                console.error('Commit image failed:', commitImage.status, errorData);
+                throw new Error(`Failed to commit image: ${errorData.message || commitImage.status}`);
+            }
 
             // 4. Create PR (GitHub Action will auto-merge)
             const createPR = await fetch(
@@ -611,7 +615,11 @@ class GitHubSync {
                     })
                 }
             );
-            if (!createPR.ok) throw new Error('Failed to create PR');
+            if (!createPR.ok) {
+                const errorData = await createPR.json().catch(() => ({}));
+                console.error('Create PR failed:', createPR.status, errorData);
+                throw new Error(`Failed to create PR: ${errorData.message || createPR.status}`);
+            }
 
             // Return the path - image will be available after PR merges (~30-60s)
             return path;

--- a/shared.js
+++ b/shared.js
@@ -1835,6 +1835,10 @@ class CardEditorModal {
                 `Update image: ${filename}`
             );
 
+            if (!committedPath) {
+                throw new Error('Failed to create PR - check console for details');
+            }
+
             // Update the input field
             imgInput.value = committedPath;
             this.updateImagePreview(`data:image/webp;base64,${base64Data}`);


### PR DESCRIPTION
## Summary
- Check if `commitImageViaPR` returns null and show error to user
- Log actual GitHub API error response when commit or PR creation fails
- Surface specific error messages instead of generic failures

## Test plan
- [ ] Try editing an image - if it fails, should see specific error message
- [ ] Check console for detailed error info