### PR TITLE
Remove SportsCardsPro attribution from footer

### DIFF
--- a/washington-qbs-rookie-checklist.html
+++ b/washington-qbs-rookie-checklist.html
@@ -369,7 +369,7 @@
         </div><!-- end page-content -->
 
         <footer>
-            <p>Prices are estimates for raw/ungraded cards. Data from SportsCardsPro.</p>
+            <p>Prices are estimates for raw/ungraded cards.</p>
             <p>Super Bowl champions highlighted with gold badge.</p>
         </footer>
     </div>


### PR DESCRIPTION
Prices are user-entered, not from SportsCardsPro. Keep the links for price checking but remove the attribution.