### PR TITLE
Add customizable price search field to card editor

### DIFF
--- a/jayden-daniels-rookie-checklist.html
+++ b/jayden-daniels-rookie-checklist.html
@@ -275,7 +275,7 @@
             const owned = isOwned(cardId);
             const price = estimatePrice(card);
             const searchUrl = CardRenderer.getEbayUrl(card.search);
-            const scpUrl = CardRenderer.getScpUrl(card.search);
+            const scpUrl = CardRenderer.getScpUrl(card.priceSearch || card.search);
             // Clean up type/variant for display: remove "RC" (all cards are rookies) and "Base" (it's the default)
             const displayType = (card.type || '').replace(/\s*RC\b/gi, '').replace(/\bBase\b/gi, '').trim();
             const displayVariant = (card.variant && card.variant !== 'Base') ? card.variant : '';
@@ -455,6 +455,11 @@
                         if (cardData.ebay) {
                             card.search = cardData.ebay;
                             delete card.ebay;
+                        }
+                        if (cardData.priceSearch) {
+                            card.priceSearch = cardData.priceSearch;
+                        } else {
+                            delete card.priceSearch;
                         }
                         // Delete optional properties that were cleared
                         if (!('price' in cardData)) delete card.price;

--- a/jmu-pro-players-checklist.html
+++ b/jmu-pro-players-checklist.html
@@ -397,7 +397,8 @@
             const owned = isOwned(cardId);
             const price = card.price;
             const searchUrl = CardRenderer.getEbayUrl(card.search);
-            const scpUrl = CardRenderer.getScpUrl(encodeURIComponent(card.player + ' rookie'));
+            const priceSearchTerm = card.priceSearch || encodeURIComponent(card.player + ' rookie');
+            const scpUrl = CardRenderer.getScpUrl(priceSearchTerm);
             // Clean up type/variant for display: remove "RC" (redundant for rookies) and "Base" (it's the default)
             const displayType = (card.type || '').replace(/\s*RC\b/gi, '').replace(/\bBase\b/gi, '').trim();
             const displayVariant = (card.variant && card.variant !== 'Base') ? card.variant : '';
@@ -604,6 +605,8 @@
                         if ('auto' in cardData) card.auto = cardData.auto;
                         else delete card.auto;
                         if (cardData.ebay) card.search = cardData.ebay;
+                        if (cardData.priceSearch) card.priceSearch = cardData.priceSearch;
+                        else delete card.priceSearch;
                         // Remove from old category
                         cards[oldCategory].splice(index, 1);
                         // Insert into (possibly new) category

--- a/shared.js
+++ b/shared.js
@@ -1788,10 +1788,15 @@ class CardEditorModal {
                         </div>
                         <div class="card-editor-field full-width card-editor-advanced-toggle">
                             <button type="button" class="card-editor-toggle-btn" id="editor-toggle-ebay">Customize eBay search</button>
+                            <button type="button" class="card-editor-toggle-btn" id="editor-toggle-price-search">Customize price search</button>
                         </div>
                         <div class="card-editor-field full-width card-editor-ebay-field" style="display: none;">
                             <label class="card-editor-label">eBay Search Term</label>
                             <input type="text" class="card-editor-input" id="editor-ebay" placeholder="Auto-generate from card data">
+                        </div>
+                        <div class="card-editor-field full-width card-editor-price-search-field" style="display: none;">
+                            <label class="card-editor-label">Price Search Term</label>
+                            <input type="text" class="card-editor-input" id="editor-price-search" placeholder="Auto-generate from player name">
                         </div>
                         <div class="card-editor-field full-width card-editor-image-section">
                             <label class="card-editor-label">Image</label>
@@ -1871,6 +1876,15 @@ class CardEditorModal {
         this.backdrop.querySelector('#editor-ebay').oninput = () => {
             this.ebayManuallyEdited = true;
             this.setDirty(true);
+        };
+
+        // Toggle price search field visibility
+        const priceSearchToggle = this.backdrop.querySelector('#editor-toggle-price-search');
+        const priceSearchField = this.backdrop.querySelector('.card-editor-price-search-field');
+        priceSearchToggle.onclick = () => {
+            const isHidden = priceSearchField.style.display === 'none';
+            priceSearchField.style.display = isHidden ? 'flex' : 'none';
+            priceSearchToggle.textContent = isHidden ? 'Hide price search' : 'Customize price search';
         };
 
         // Image preview on URL change
@@ -2319,6 +2333,15 @@ class CardEditorModal {
         ebayField.style.display = hasCustomEbay ? 'flex' : 'none';
         ebayToggle.textContent = hasCustomEbay ? 'Hide eBay search' : 'Customize eBay search';
 
+        // Populate and show price search field if it has a custom value
+        const priceSearchValue = cardData.priceSearch || '';
+        this.backdrop.querySelector('#editor-price-search').value = priceSearchValue;
+        const priceSearchField = this.backdrop.querySelector('.card-editor-price-search-field');
+        const priceSearchToggle = this.backdrop.querySelector('#editor-toggle-price-search');
+        const hasCustomPriceSearch = priceSearchValue !== '';
+        priceSearchField.style.display = hasCustomPriceSearch ? 'flex' : 'none';
+        priceSearchToggle.textContent = hasCustomPriceSearch ? 'Hide price search' : 'Customize price search';
+
         this.updateImagePreview(cardData.img);
         this.updateProcessButton(cardData.img);
         this.updateEditButton(cardData.img);
@@ -2360,6 +2383,11 @@ class CardEditorModal {
         // Hide eBay field by default for new cards
         this.backdrop.querySelector('.card-editor-ebay-field').style.display = 'none';
         this.backdrop.querySelector('#editor-toggle-ebay').textContent = 'Customize eBay search';
+
+        // Hide price search field by default for new cards
+        this.backdrop.querySelector('#editor-price-search').value = '';
+        this.backdrop.querySelector('.card-editor-price-search-field').style.display = 'none';
+        this.backdrop.querySelector('#editor-toggle-price-search').textContent = 'Customize price search';
 
         // Clear custom fields
         this.clearCustomFields();
@@ -2438,6 +2466,12 @@ class CardEditorModal {
         const ebayVal = this.backdrop.querySelector('#editor-ebay').value.trim();
         if (ebayVal !== '') {
             data.ebay = ebayVal;
+        }
+
+        // Price search term - only include if explicitly set
+        const priceSearchVal = this.backdrop.querySelector('#editor-price-search').value.trim();
+        if (priceSearchVal !== '') {
+            data.priceSearch = priceSearchVal;
         }
 
         // Preserve category if editing and no category dropdown exists

--- a/washington-qbs-rookie-checklist.html
+++ b/washington-qbs-rookie-checklist.html
@@ -569,7 +569,8 @@
 
             const cardClass = `card ${cardOwned ? 'owned' : ''} ${card.superBowl ? 'super-bowl' : ''}`;
             const searchUrl = CardRenderer.getEbayUrl(card.search);
-            const scpUrl = CardRenderer.getScpUrl(encodeURIComponent(card.player + ' rookie'));
+            const priceSearchTerm = card.priceSearch || encodeURIComponent(card.player + ' rookie');
+            const scpUrl = CardRenderer.getScpUrl(priceSearchTerm);
 
             return `<div class="${cardClass}">
                 <div class="card-image-wrapper">
@@ -792,6 +793,8 @@
                         if ('achievement' in cardData && cardData.achievement.length > 0) foundCard.achievement = cardData.achievement;
                         else delete foundCard.achievement;
                         if (cardData.ebay) foundCard.search = cardData.ebay;
+                        if (cardData.priceSearch) foundCard.priceSearch = cardData.priceSearch;
+                        else delete foundCard.priceSearch;
                         // Re-sort: remove from current position and re-insert sorted
                         cards.splice(index, 1);
                         insertCardSorted(foundCard);


### PR DESCRIPTION
## Summary
- Added "Customize price search" toggle in card editor (similar to eBay search)
- Price links now use `card.priceSearch` if set, otherwise fall back to auto-generated search
- Works on all three checklist pages

## Test plan
- [ ] Edit a card on Jayden Daniels page
- [ ] Click "Customize price search" toggle
- [ ] Enter a custom search term and save
- [ ] Verify the Prices link uses the custom term
- [ ] Clear the field and save - verify it falls back to default