### PR TITLE
Add auto-deployment for Cloudflare Worker

### DIFF
--- a/.github/workflows/deploy-worker.yml
+++ b/.github/workflows/deploy-worker.yml
@@ -1,0 +1,22 @@
+name: Deploy Cloudflare Worker
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'worker.js'
+      - 'wrangler.toml'
+  workflow_dispatch:
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Deploy to Cloudflare Workers
+        uses: cloudflare/wrangler-action@v3
+        with:
+          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -1,0 +1,9 @@
+# Cloudflare Worker configuration
+# https://developers.cloudflare.com/workers/wrangler/configuration/
+
+name = "cards-oauth"
+main = "worker.js"
+compatibility_date = "2024-01-01"
+
+# Account ID is set via CLOUDFLARE_ACCOUNT_ID secret in GitHub Actions
+# Environment variables (GITHUB_CLIENT_ID, etc.) are configured in Cloudflare dashboard


### PR DESCRIPTION
## Summary
Enables automatic deployment of the Cloudflare Worker (`worker.js`) when changes merge to main.

- Adds `wrangler.toml` configuration
- Adds GitHub Action that deploys only when `worker.js` or `wrangler.toml` change
- Supports manual trigger via workflow_dispatch

Closes #302

## Setup required
After merging, add these secrets to the repo (Settings > Secrets > Actions):

1. **CLOUDFLARE_API_TOKEN**
   - Go to [Cloudflare API Tokens](https://dash.cloudflare.com/profile/api-tokens)
   - Create token with "Edit Cloudflare Workers" template
   - Copy the token value

2. **CLOUDFLARE_ACCOUNT_ID**
   - Found in Cloudflare dashboard URL: `dash.cloudflare.com/<ACCOUNT_ID>/...`
   - Or: Workers & Pages > Overview > right sidebar

## Test plan
- [ ] Add secrets to GitHub repo
- [ ] Make a small change to `worker.js` (e.g., add a comment)
- [ ] Merge and verify the Action runs successfully
- [ ] Verify worker still works at https://cards-oauth.iammikec.workers.dev