### PR TITLE
Fix OAuth: add client IDs to wrangler.toml

### DIFF
--- a/wrangler.toml
+++ b/wrangler.toml
@@ -6,4 +6,8 @@ main = "worker.js"
 compatibility_date = "2024-01-01"
 
 # Account ID is set via CLOUDFLARE_ACCOUNT_ID secret in GitHub Actions
-# Environment variables (GITHUB_CLIENT_ID, etc.) are configured in Cloudflare dashboard
+# Secrets (GITHUB_CLIENT_SECRET, GITHUB_CLIENT_SECRET_PREVIEW) are configured in Cloudflare dashboard
+
+[vars]
+GITHUB_CLIENT_ID = "Ov23liik9Fs5C6RCeTgf"
+GITHUB_CLIENT_ID_PREVIEW = "Ov23limT2ZxKxthkupeT"


### PR DESCRIPTION
## Summary
- The wrangler deploy from #389 cleared the dashboard-configured environment variables, breaking OAuth login on all pages.dev sites (preview and main)
- Pin the non-secret `GITHUB_CLIENT_ID` and `GITHUB_CLIENT_ID_PREVIEW` in `wrangler.toml` so they survive future deployments
- Secrets (`GITHUB_CLIENT_SECRET`, `GITHUB_CLIENT_SECRET_PREVIEW`) remain in the Cloudflare dashboard

## Test plan
- [ ] Merge PR (triggers worker redeploy with the vars)
- [ ] Verify OAuth login works on main `sports-card-checklists.pages.dev`
- [ ] Verify OAuth login works on a branch preview site