### PR TITLE
Fix search filter not reapplying after card edit/delete

### DIFF
--- a/jayden-daniels-rookie-checklist.html
+++ b/jayden-daniels-rookie-checklist.html
@@ -483,6 +483,7 @@
                     }
                 }
                 renderCards();
+                applyFilters();
                 // Save to GitHub repo
                 checklistManager.setSyncStatus('syncing', 'Saving...');
                 await saveCardDataToRepo();
@@ -498,6 +499,7 @@
                     }
                 }
                 renderCards();
+                applyFilters();
                 // Save to GitHub repo
                 checklistManager.setSyncStatus('syncing', 'Saving...');
                 await saveCardDataToRepo();

--- a/jmu-pro-players-checklist.html
+++ b/jmu-pro-players-checklist.html
@@ -628,6 +628,7 @@
                     }
                 }
                 renderCards();
+                applyFilters();
                 // Save to GitHub repo
                 checklistManager.setSyncStatus('syncing', 'Saving...');
                 await saveCardDataToRepo();
@@ -642,6 +643,7 @@
                     }
                 }
                 renderCards();
+                applyFilters();
                 // Save to GitHub repo
                 checklistManager.setSyncStatus('syncing', 'Saving...');
                 await saveCardDataToRepo();


### PR DESCRIPTION
## Summary
- Adds `applyFilters()` call after `renderCards()` in onSave and onDelete handlers for Jayden Daniels and JMU pages
- Washington QBs page not affected (its `render()` already filters inline)

Fixes #396

## Test plan
- [ ] Search for a card on the Jayden Daniels page, edit a filtered result, save - filter should stay active
- [ ] Same test on JMU page
- [ ] Delete a card while search is active - filter should stay active