### PR TITLE
Add perspective correction to image editor

### DIFF
--- a/shared.css
+++ b/shared.css
@@ -2070,6 +2070,70 @@ select, input[type="text"] {
     transform: scale(0.95);
 }
 
+/* ============================================
+   Image Editor - Perspective Mode
+   ============================================ */
+
+.image-editor-canvas {
+    position: relative;
+}
+
+.image-editor-tool.active {
+    background: rgba(102, 126, 234, 0.3);
+    border-color: rgba(102, 126, 234, 0.6);
+    color: white;
+}
+
+.perspective-canvas {
+    max-width: 100%;
+    max-height: 100%;
+    display: block;
+}
+
+.perspective-overlay {
+    position: absolute;
+    top: 0;
+    left: 0;
+    pointer-events: none;
+}
+
+.perspective-handle {
+    position: absolute;
+    width: 24px;
+    height: 24px;
+    border-radius: 50%;
+    background: rgba(102, 126, 234, 0.9);
+    border: 2px solid white;
+    cursor: grab;
+    transform: translate(-50%, -50%);
+    z-index: 10;
+    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.4);
+    touch-action: none;
+    transition: background 0.15s, transform 0.1s;
+}
+
+.perspective-handle:hover {
+    background: rgba(102, 126, 234, 1);
+    transform: translate(-50%, -50%) scale(1.15);
+}
+
+.perspective-handle:active,
+.perspective-handle.dragging {
+    cursor: grabbing;
+    background: #667eea;
+    transform: translate(-50%, -50%) scale(1.2);
+    box-shadow: 0 4px 12px rgba(102, 126, 234, 0.5);
+}
+
+.perspective-controls {
+    display: none;
+    align-items: center;
+    justify-content: center;
+    padding: 12px 24px;
+    color: rgba(255, 255, 255, 0.5);
+    font-size: 13px;
+}
+
 @media (max-width: 600px) {
     .image-editor-modal {
         width: 100vw;
@@ -2095,5 +2159,10 @@ select, input[type="text"] {
 
     .image-editor-slider {
         width: 80px;
+    }
+
+    .perspective-handle {
+        width: 32px;
+        height: 32px;
     }
 }


### PR DESCRIPTION
## Summary
- Adds a perspective/keystone correction mode to the image editor (#332)
- Users can drag 4 corner handles to match card edges, then apply a homography transform to straighten the image
- Custom implementation using DLT algorithm with bilinear interpolation - no external dependencies
- Fully integrates with existing Cropper.js workflow: perspective correction -> crop/rotate -> save

## Test plan
- [ ] Open image editor on a card with an angled/keystoned photo
- [ ] Click the Perspective button in the footer
- [ ] Verify 4 corner handles appear with guide lines connecting them
- [ ] Drag corners to match card edges, verify handles stay within bounds
- [ ] Click Apply Correction, verify the image is straightened
- [ ] Verify Cropper.js reloads with the corrected image for crop/rotate
- [ ] Cancel in perspective mode returns to Cropper without changes
- [ ] Reset in crop mode after perspective correction restores original image
- [ ] Test on mobile (touch dragging of handles)