### PR TITLE
Constrain perspective canvas to prevent overflow

### DIFF
--- a/shared.css
+++ b/shared.css
@@ -2086,7 +2086,7 @@ select, input[type="text"] {
 
 .perspective-canvas {
     max-width: 100%;
-    max-height: 100%;
+    max-height: 60vh;
     display: block;
 }
 
@@ -2159,6 +2159,10 @@ select, input[type="text"] {
 
     .image-editor-slider {
         width: 80px;
+    }
+
+    .perspective-canvas {
+        max-height: none;
     }
 
     .perspective-handle {


### PR DESCRIPTION
## Summary
- Perspective canvas was using `max-height: 100%` which doesn't resolve against a flex parent's `max-height`
- Large/tall images would overflow the editor, making corner handles unreachable
- Changed to `max-height: 60vh` to match the editor canvas container constraint
- Mobile override removes the constraint (full-screen editor)

## Test plan
- [ ] Open perspective mode on a tall/large image - canvas should fit within the editor
- [ ] Corner handles should be visible and draggable at all four corners
- [ ] Test on mobile - image should fill available space