### PR TITLE
Open image editor in perspective mode by default

### DIFF
--- a/shared.js
+++ b/shared.js
@@ -1586,7 +1586,10 @@ class ImageEditorModal {
             this.rejectPromise = reject;
 
             img.onload = () => {
-                this.cropper = new Cropper(img, this.cropperOptions);
+                this.cropper = new Cropper(img, {
+                    ...this.cropperOptions,
+                    ready: () => this.enterPerspectiveMode(),
+                });
             };
             img.onerror = () => reject(new Error('Failed to load image'));
         });


### PR DESCRIPTION
## Summary
- Image editor now opens directly in perspective correction mode instead of crop mode
- Cropper.js initializes behind the scenes, then immediately switches to perspective
- After applying correction (or canceling), user proceeds to crop/rotate as before

## Test plan
- [ ] Open image editor - should start in perspective mode with corner handles
- [ ] Apply correction, verify it transitions to crop mode
- [ ] Cancel perspective, verify it transitions to crop mode with original image