### PR TITLE
Add finer grid overlay to crop editor

### DIFF
--- a/shared.css
+++ b/shared.css
@@ -1897,6 +1897,14 @@ select, input[type="text"] {
     justify-content: center;
 }
 
+/* Finer grid overlay on crop box for alignment */
+.image-editor-canvas .cropper-face {
+    background-image:
+        linear-gradient(to right, rgba(255, 255, 255, 0.15) 1px, transparent 1px),
+        linear-gradient(to bottom, rgba(255, 255, 255, 0.15) 1px, transparent 1px);
+    background-size: 20% 20%;
+}
+
 .image-editor-canvas img {
     max-width: 100%;
     max-height: 100%;


### PR DESCRIPTION
## Summary
- Adds a 5x5 grid (lines at every 20%) overlaid on the crop box
- Subtle white lines (15% opacity) for alignment without obscuring the image
- CSS-only change using background gradients on `.cropper-face`

## Test plan
- [ ] Open image editor in crop mode - verify grid lines visible on crop area
- [ ] Verify grid is subtle enough to not obscure image detail
- [ ] Verify grid scales with crop box resizing