### PR TITLE
Revert crop grid overlay

### DIFF
--- a/shared.css
+++ b/shared.css
@@ -1897,14 +1897,6 @@ select, input[type="text"] {
     justify-content: center;
 }
 
-/* Finer grid overlay on crop box for alignment */
-.image-editor-canvas .cropper-face {
-    background-image:
-        linear-gradient(to right, rgba(255, 255, 255, 0.15) 1px, transparent 1px),
-        linear-gradient(to bottom, rgba(255, 255, 255, 0.15) 1px, transparent 1px);
-    background-size: 20% 20%;
-}
-
 .image-editor-canvas img {
     max-width: 100%;
     max-height: 100%;


### PR DESCRIPTION
Reverts the grid lines added in #420 - CSS wasn't overriding Cropper.js styles and the feature isn't needed.