### PR TITLE
Suppress iOS native context menu on card long press

### DIFF
--- a/shared.css
+++ b/shared.css
@@ -704,6 +704,8 @@ select, input[type="text"] {
     position: relative;
     display: flex;
     flex-direction: column;
+    -webkit-touch-callout: none;
+    user-select: none;
 }
 
 .card:hover {


### PR DESCRIPTION
## Summary
Adds `-webkit-touch-callout: none` and `user-select: none` to `.card` to prevent the native iOS callout/preview popup from appearing alongside our custom context menu on long press.

Fixes #441

## Test plan
- [ ] On iOS, long press a card - verify only the custom Edit/Delete context menu appears (no native iOS preview/copy menu)
- [ ] Verify tapping cards, links (eBay/Prices), and toggle-owned still work normally
- [ ] Verify right-click context menu still works on desktop