### PR TITLE
Prevent image lift and text selection on card long press

### DIFF
--- a/shared.css
+++ b/shared.css
@@ -705,7 +705,13 @@ select, input[type="text"] {
     display: flex;
     flex-direction: column;
     -webkit-touch-callout: none;
+    -webkit-user-select: none;
     user-select: none;
+}
+
+.card * {
+    -webkit-user-drag: none;
+    -webkit-touch-callout: none;
 }
 
 .card:hover {


### PR DESCRIPTION
## Summary
Follow-up to #444. On iOS, long-pressing a card image caused it to "lift" in the z-dimension (drag preview), and price text was still getting highlighted despite `user-select: none`.

- `-webkit-user-drag: none` on all card children prevents the iOS image lift
- `-webkit-touch-callout: none` on all card children ensures no child triggers a callout
- `-webkit-user-select: none` for broader iOS text selection prevention

## Test plan
- [ ] Long press on a card image - no image lift/z-elevation effect
- [ ] Long press on price text - no text highlighting
- [ ] Tap card image still opens eBay link
- [ ] Custom context menu still appears on long press