### PR TITLE
Allow saving cards with just a player name and no set name

### DIFF
--- a/checklist-engine.js
+++ b/checklist-engine.js
@@ -529,7 +529,7 @@ class ChecklistEngine {
 
     getCardId(card) {
         if (this.config.cardDisplay?.includePlayerInCardId) {
-            return btoa((card.player || '') + card.set + card.num + (card.variant || '')).replace(/[^a-zA-Z0-9]/g, '');
+            return btoa((card.player || '') + (card.set || '') + (card.num || '') + (card.variant || '')).replace(/[^a-zA-Z0-9]/g, '');
         }
         return this.checklistManager.getCardId(card);
     }
@@ -623,8 +623,8 @@ class ChecklistEngine {
             html += `<div class="card-info"><span class="card-set">${sanitizeText(card.set)}</span> ${sanitizeText(card.num)}</div>`;
         } else {
             // Standard style: set title, number + variant, type
-            html += `<div class="card-title">${sanitizeText(card.set)}</div>`;
-            html += `<div class="card-number">${sanitizeText(card.num)} ${sanitizeText(displayVariant)}</div>`;
+            if (card.set) html += `<div class="card-title">${sanitizeText(card.set)}</div>`;
+            if (card.num || displayVariant) html += `<div class="card-number">${sanitizeText(card.num)} ${sanitizeText(displayVariant)}</div>`;
             if (displayType) {
                 html += `<div class="card-type">${sanitizeText(displayType)}</div>`;
             }

--- a/shared.js
+++ b/shared.js
@@ -2914,15 +2914,27 @@ class CardEditorModal {
         return data;
     }
 
-    // Validate form
+    // Validate form - require set name OR a top-position custom field (e.g. player name)
     validate() {
         const data = this.getFormData();
-        if (!data.set) {
+        if (data.set) return true;
+
+        // Check if any top-position custom field has a value
+        const hasTopField = Object.entries(this.customFields)
+            .some(([name, config]) => (config.position || 'top') === 'top' && data[name]);
+        if (hasTopField) return true;
+
+        // Nothing filled in - focus the first visible field
+        const topField = Object.entries(this.customFields)
+            .find(([_, c]) => (c.position || 'top') === 'top');
+        if (topField) {
+            alert(`${topField[1].label} or Set Name is required`);
+            this.backdrop.querySelector(`#editor-${topField[0]}`)?.focus();
+        } else {
             alert('Set name is required');
             this.backdrop.querySelector('#editor-set').focus();
-            return false;
         }
-        return true;
+        return false;
     }
 
     // Check if image URL needs processing (external URL from supported domain)


### PR DESCRIPTION
## Summary
On checklists with a player name field (like UConn Women's Basketball), you can now save a card with just the player name - no set name required. This supports the "one card per player" use case where you add a placeholder card for each player and fill in card details later.

- Validation accepts set name **or** any top-position custom field (e.g. player name)
- Checklists without a player name field still require set name as before
- Cards without a set skip rendering empty title/number divs
- Fixed potential undefined concatenation in card ID generation

## Test plan
- [ ] On a checklist with player name field: add a card with only player name, no set - verify it saves
- [ ] Verify the card displays cleanly (just player name, no empty space where set would be)
- [ ] On a checklist without player name: verify set name is still required
- [ ] Edit a player-only card, add a set name later - verify it displays correctly
- [ ] CI passes