### PR TITLE
Add owned toggle to card editor modal

### DIFF
--- a/checklist-engine.js
+++ b/checklist-engine.js
@@ -1185,6 +1185,19 @@ class ChecklistEngine {
             imageFolder: `images/${this.id}`,
             categories: editorCategories,
             cardTypes: [],
+            isOwned: (cardId) => this.checklistManager.isOwned(cardId),
+            onOwnedChange: (cardId, cardData, nowOwned) => {
+                // For new cards, compute the cardId from the data
+                const id = cardId || this.getCardId(cardData);
+                this.checklistManager.toggleOwned(id, nowOwned);
+                const cardEl = document.querySelector(`.card[data-id="${id}"]`);
+                if (cardEl) {
+                    cardEl.classList.toggle('owned', nowOwned);
+                    const checkbox = cardEl.querySelector(`input[type="checkbox"]`);
+                    if (checkbox) checkbox.checked = nowOwned;
+                }
+                this.updateStats();
+            },
             onSave: async (cardId, cardData, isNew) => {
                 if (isNew) {
                     this._addCard(cardData);

--- a/jayden-daniels-rookie-checklist.html
+++ b/jayden-daniels-rookie-checklist.html
@@ -433,6 +433,18 @@
             },
             imageFolder: 'images/jayden-daniels',
             categories: ['college', 'panini', 'topps', 'other', 'inserts', 'premium'],
+            isOwned: (cardId) => checklistManager.isOwned(cardId),
+            onOwnedChange: (cardId, cardData, nowOwned) => {
+                const id = cardId || getCardId(cardData);
+                checklistManager.toggleOwned(id, nowOwned);
+                const cardEl = document.querySelector(`.card[data-id="${id}"]`);
+                if (cardEl) {
+                    cardEl.classList.toggle('owned', nowOwned);
+                    const checkbox = cardEl.querySelector(`input[type="checkbox"]`);
+                    if (checkbox) checkbox.checked = nowOwned;
+                }
+                updateStats();
+            },
             onSave: async (cardId, cardData, isNew) => {
                 if (isNew) {
                     // Add new card to appropriate category

--- a/jmu-pro-players-checklist.html
+++ b/jmu-pro-players-checklist.html
@@ -558,6 +558,18 @@
                 { value: 'MLS', label: 'MLS' }
             ],
             imageFolder: 'images/jmu-pro-players',
+            isOwned: (cardId) => checklistManager.isOwned(cardId),
+            onOwnedChange: (cardId, cardData, nowOwned) => {
+                const id = cardId || getCardId(cardData);
+                checklistManager.toggleOwned(id, nowOwned);
+                const cardEl = document.querySelector(`.card[data-id="${id}"]`);
+                if (cardEl) {
+                    cardEl.classList.toggle('owned', nowOwned);
+                    const checkbox = cardEl.querySelector(`input[type="checkbox"]`);
+                    if (checkbox) checkbox.checked = nowOwned;
+                }
+                updateStats();
+            },
             onSave: async (cardId, cardData, isNew) => {
                 if (isNew) {
                     // Add new card - category is now sport (NFL, MLB, etc.)

--- a/shared.css
+++ b/shared.css
@@ -1270,6 +1270,47 @@ select, input[type="text"] {
     padding: 20px 24px 16px;
     border-bottom: 1px solid rgba(255, 255, 255, 0.06);
     position: relative;
+    display: flex;
+    align-items: flex-start;
+    gap: 12px;
+}
+
+.card-editor-header-left {
+    flex: 1;
+    min-width: 0;
+}
+
+.card-editor-owned-toggle {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    cursor: pointer;
+    padding: 6px 0;
+    margin-right: 28px;
+    -webkit-user-select: none;
+    user-select: none;
+}
+
+.card-editor-owned-toggle input[type="checkbox"] {
+    width: 18px;
+    height: 18px;
+    accent-color: #27ae60;
+    cursor: pointer;
+    margin: 0;
+}
+
+.card-editor-owned-toggle .owned-toggle-label {
+    font-family: 'Barlow', sans-serif;
+    font-size: 0.8em;
+    font-weight: 600;
+    letter-spacing: 0.05em;
+    text-transform: uppercase;
+    color: #888;
+    transition: color 0.15s;
+}
+
+.card-editor-owned-toggle input:checked + .owned-toggle-label {
+    color: #27ae60;
 }
 
 .card-editor-title {

--- a/washington-qbs-rookie-checklist.html
+++ b/washington-qbs-rookie-checklist.html
@@ -759,6 +759,18 @@
             },
             priceInAttributes: true,
             imageFolder: 'images/washington-qbs',
+            isOwned: (cardId) => checklistManager.isOwned(cardId),
+            onOwnedChange: (cardId, cardData, nowOwned) => {
+                const id = cardId || getCardId(cardData);
+                checklistManager.toggleOwned(id, nowOwned);
+                const cardEl = document.querySelector(`.card[data-id="${id}"]`);
+                if (cardEl) {
+                    cardEl.classList.toggle('owned', nowOwned);
+                    const checkbox = cardEl.querySelector(`input[type="checkbox"]`);
+                    if (checkbox) checkbox.checked = nowOwned;
+                }
+                updateStats();
+            },
             onSave: async (cardId, cardData, isNew) => {
                 if (isNew) {
                     // Add new card


### PR DESCRIPTION
## Summary
- Adds an "Owned" checkbox in the card editor header, next to the title
- When saving, if owned state changed, updates the card's owned status and syncs UI
- Works across all pages: config-driven checklists and all three legacy pages
- Toggle is hidden when no `onOwnedChange` callback is provided (backwards-compatible)

## Test plan
- [ ] Open a card editor on any checklist - owned checkbox visible in header
- [ ] Edit an unowned card, check "Owned", save - card shows as owned
- [ ] Edit an owned card, uncheck "Owned", save - card shows as unowned
- [ ] Toggle owned without changing other fields - still saves correctly
- [ ] Add a new card with "Owned" checked - card added and marked owned
- [ ] Verify on legacy pages (Jayden, JMU, QBs) as well