### PR TITLE
Fix title invisible in light mode

### DIFF
--- a/checklist-engine.js
+++ b/checklist-engine.js
@@ -356,7 +356,7 @@ class ChecklistEngine {
                 background: linear-gradient(90deg, transparent, ${accent}, transparent);
             }
             h1 {
-                background: linear-gradient(180deg, #333 0%, ${primary} 100%);
+                background: linear-gradient(180deg, #e0e0e0 0%, ${accent} 100%);
                 -webkit-background-clip: text;
                 -webkit-text-fill-color: transparent;
                 background-clip: text;


### PR DESCRIPTION
## Summary
- Page header always has a dark background, but light mode h1 used a dark-on-dark gradient (#333 to primary color)
- Changed light mode h1 to use #e0e0e0 to accent, matching the dark mode approach

## Test plan
- [ ] UConn checklist in light mode - title visible
- [ ] UConn checklist in dark mode - title still visible
- [ ] Other checklists unaffected