### PR TITLE
Scroll to card after save

### DIFF
--- a/checklist-engine.js
+++ b/checklist-engine.js
@@ -1204,6 +1204,13 @@ class ChecklistEngine {
                 }
                 this.renderCards();
                 this.updateStats();
+                // Scroll to the card
+                const newId = this.getCardId(cardData);
+                const cardEl = document.querySelector(`.card[data-id="${newId}"]`);
+                if (cardEl) {
+                    cardEl.scrollIntoView({ behavior: 'smooth', block: 'center' });
+                    if (isNew) cardEl.classList.add('card-highlight');
+                }
                 this.checklistManager.setSyncStatus('syncing', 'Saving...');
                 await this._saveCardData();
             },

--- a/shared.css
+++ b/shared.css
@@ -2725,6 +2725,15 @@ select, input[type="text"] {
     animation: row-flash 0.4s ease-out;
 }
 
+@keyframes card-highlight-pulse {
+    0% { box-shadow: 0 0 0 3px rgba(102, 126, 234, 0.6); }
+    100% { box-shadow: none; }
+}
+
+.card-highlight {
+    animation: card-highlight-pulse 1.5s ease-out forwards;
+}
+
 @keyframes row-flash {
     0% { border-color: rgba(102, 126, 234, 0.5); }
     100% { border-color: rgba(255, 255, 255, 0.06); }


### PR DESCRIPTION
## Summary
- After adding or editing a card, smooth-scrolls to it in the list
- New cards get a brief blue glow highlight animation so they're easy to spot

## Test plan
- [ ] Add a new card - page scrolls to it with a highlight pulse
- [ ] Edit an existing card - page scrolls to it