### PR TITLE
Start perspective handles at image edges

### DIFF
--- a/shared.js
+++ b/shared.js
@@ -1732,7 +1732,7 @@ class ImageEditorModal {
 
     // Reset corner handles to default inset positions
     resetCornerHandles() {
-        const inset = 0.05;
+        const inset = 0;
         this.cornerPositions = [
             { x: inset, y: inset },
             { x: 1 - inset, y: inset },


### PR DESCRIPTION
## Summary
- Changed perspective corner handle inset from 5% to 0%, so handles start at the extreme edges of the image instead of being padded in

## Test plan
- [ ] Open image editor on a card
- [ ] Enter perspective mode
- [ ] Verify corner handles appear at the exact corners of the image