### PR TITLE
Fix auto-merge workflow for image PRs

### DIFF
--- a/.github/workflows/auto-merge-images.yml
+++ b/.github/workflows/auto-merge-images.yml
@@ -40,14 +40,14 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Merge PR
+      - name: Approve PR
         if: steps.check.outputs.should_merge == 'true'
-        run: gh pr merge ${{ github.event.pull_request.number }} --squash --delete-branch
+        run: gh pr review ${{ github.event.pull_request.number }} --approve
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Trigger deploy
+      - name: Enable auto-merge
         if: steps.check.outputs.should_merge == 'true'
-        run: gh workflow run deploy.yml
+        run: gh pr merge ${{ github.event.pull_request.number }} --squash --delete-branch --auto
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
- Auto-merge workflow was failing because branch protection blocks direct merges via `GITHUB_TOKEN`
- Changed to approve PR + enable auto-merge (`--auto`), so image PRs merge after required checks pass
- Removed manual deploy trigger since merge to main triggers deploy naturally

## Test plan
- [ ] Upload an image on a card and verify the PR auto-merges after tests pass