### PR TITLE
Fix image editor stuck open behind card editor

### DIFF
--- a/shared.css
+++ b/shared.css
@@ -1991,7 +1991,7 @@ select, input[type="text"] {
     display: flex;
     align-items: center;
     justify-content: center;
-    z-index: 10000;
+    z-index: 10001;
     opacity: 0;
     visibility: hidden;
     transition: opacity 0.2s ease, visibility 0.2s ease;

--- a/shared.js
+++ b/shared.js
@@ -1596,7 +1596,10 @@ class ImageEditorModal {
                     ready: () => this.enterPerspectiveMode(),
                 });
             };
-            img.onerror = () => reject(new Error('Failed to load image'));
+            img.onerror = () => {
+                this.close();
+                reject(new Error('Failed to load image'));
+            };
         });
     }
 
@@ -2882,6 +2885,8 @@ class CardEditorModal {
         this.currentCard = null;
         this.currentCardId = null;
         this.isNewCard = false;
+        // Close image editor if it was left open
+        imageEditor.close();
     }
 
     // Gather form data


### PR DESCRIPTION
## Summary
- When editing a card's image a second time, the image editor could get stuck open behind the card editor. Three fixes:
  - **onerror close**: if the image fails to load (e.g. 404 because PR hasn't merged), close the image editor backdrop before rejecting the promise
  - **z-index**: bump image editor from 10000 to 10001 so it always appears on top of the card editor (card editor re-creates its backdrop each time, changing DOM order)
  - **safety net**: card editor close() now also closes the image editor to prevent it from lingering

## Test plan
- [ ] Edit a card image, confirm, save card
- [ ] Edit a different card's image - verify image editor appears on top of card editor
- [ ] Close card editor without saving - verify no image editor left visible