### PR TITLE
Fix auto-merge: drop approve step, support all image folders

### DIFF
--- a/.github/workflows/auto-merge-images.yml
+++ b/.github/workflows/auto-merge-images.yml
@@ -4,14 +4,11 @@ on:
   pull_request:
     types: [opened]
     paths:
-      - 'images/jayden-daniels/**'
-      - 'images/washington-qbs/**'
-      - 'images/jmu-pro-players/**'
+      - 'images/**'
 
 permissions:
   contents: write
   pull-requests: write
-  actions: write
 
 jobs:
   auto-merge:
@@ -28,7 +25,7 @@ jobs:
 
           # Check all files are in image folders
           for FILE in $FILES; do
-            if [[ ! "$FILE" =~ ^images/(jayden-daniels|washington-qbs|jmu-pro-players)/.+\.(webp|png|jpg|jpeg)$ ]]; then
+            if [[ ! "$FILE" =~ ^images/.+\.(webp|png|jpg|jpeg)$ ]]; then
               echo "Non-image file found: $FILE"
               echo "should_merge=false" >> $GITHUB_OUTPUT
               exit 0
@@ -37,12 +34,6 @@ jobs:
 
           echo "All files are images in allowed folders"
           echo "should_merge=true" >> $GITHUB_OUTPUT
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Approve PR
-        if: steps.check.outputs.should_merge == 'true'
-        run: gh pr review ${{ github.event.pull_request.number }} --approve
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 


### PR DESCRIPTION
## Summary
- Removed the "Approve PR" step - `GITHUB_TOKEN` cannot approve PRs (GitHub policy), and branch protection only requires the `test` status check (no reviews needed)
- The workflow now just enables `--auto` merge, which queues and merges after tests pass
- Broadened paths trigger from 3 hardcoded folders to `images/**` so config-driven checklists (UConn, etc.) also get auto-merged

## Why it was failing
1. Original workflow: direct `--squash` merge blocked by branch protection (test check not passed yet)
2. First fix: added approve step, but `GITHUB_TOKEN` can't approve PRs
3. This fix: just use `--auto` to queue merge after the required `test` check passes

## Test plan
- [ ] Upload a card image and verify the PR auto-merges after tests pass (~1-2 min)