### PR TITLE
Fix image editor CORS for R2 images

### DIFF
--- a/shared.js
+++ b/shared.js
@@ -1581,8 +1581,9 @@ class ImageEditorModal {
         if (slider) slider.value = 0;
         if (input) input.value = '0°';
 
-        // Set image source
+        // Set image source (crossOrigin needed for R2 images so canvas isn't tainted)
         const img = this.backdrop.querySelector('#image-editor-img');
+        img.crossOrigin = 'anonymous';
         img.src = imageSrc;
 
         // Show modal

--- a/worker.js
+++ b/worker.js
@@ -40,6 +40,7 @@ async function handleServeImage(request, env, key) {
   headers.set('Content-Type', object.httpMetadata?.contentType || 'image/webp');
   headers.set('Cache-Control', 'public, max-age=31536000, immutable');
   headers.set('ETag', object.httpEtag);
+  headers.set('Access-Control-Allow-Origin', '*');
 
   // Support conditional requests
   const ifNoneMatch = request.headers.get('If-None-Match');


### PR DESCRIPTION
## Summary
- R2 images are cross-origin, which taints the canvas and prevents Cropper.js from functioning
- Add `Access-Control-Allow-Origin: *` to R2 image responses in the Worker
- Set `crossOrigin = 'anonymous'` on the img element in ImageEditorModal

## Test plan
- [ ] Open image editor on a card with an R2 image URL
- [ ] Verify crop/rotate/perspective controls work