### PR TITLE
Fix dark theme section-group background

### DIFF
--- a/checklist-engine.js
+++ b/checklist-engine.js
@@ -317,6 +317,9 @@ class ChecklistEngine {
                 background: linear-gradient(135deg, ${dark} 0%, #1a1a1a 100%);
                 border-bottom-color: ${accent};
             }
+            .section-group {
+                background: rgba(255,255,255,0.03);
+            }
             select, input[type="text"] {
                 border: 1px solid rgba(255,255,255,0.2);
                 background: rgba(0,0,0,0.3);


### PR DESCRIPTION
## Summary
- The `.section-group` wrapper (used for parent categories with children, like Football on JMU) wasn't overridden in dark theme, keeping its white `#f8f9fa` background from shared.css
- Adds dark theme override: `background: rgba(255,255,255,0.03)`

## Test plan
- [ ] Visit JMU page - Football section (NFL/USFL) should have dark background instead of white