### PR TITLE
Fix card image background in dark theme

### DIFF
--- a/checklist-engine.js
+++ b/checklist-engine.js
@@ -347,6 +347,16 @@ class ChecklistEngine {
                 background: rgba(0,0,0,0.3);
                 border-radius: 8px;
             }
+            .card-image {
+                background: #1a1a1a;
+            }
+            .card-image.placeholder {
+                border-color: rgba(255,255,255,0.15);
+                color: rgba(255,255,255,0.4);
+            }
+            .card-image.placeholder:hover {
+                background: rgba(255,255,255,0.05);
+            }
             `;
         } else {
             // Light theme overrides - keep it clean, let colors come through in accents


### PR DESCRIPTION
## Summary
- Card images use `object-fit: contain`, so any space around the image shows the element's background color
- `.card-image` had `background: #fafafa` from shared.css, appearing as white space around card images on dark themed pages
- Override to `#1a1a1a` in dark theme so the padding area matches the dark background
- Also fix placeholder card styles for dark theme (border, text color, hover)

## Test plan
- [ ] Visit JMU page - card images should have dark background instead of white around edges
- [ ] Placeholder cards (no image) should look correct on dark theme