### PR TITLE
Use transparent image background in dark theme

### DIFF
--- a/checklist-engine.js
+++ b/checklist-engine.js
@@ -344,11 +344,11 @@ class ChecklistEngine {
             }
             .player-name { color: ${textColor}; }
             .card-image-wrapper {
-                background: rgba(0,0,0,0.3);
+                background: transparent;
                 border-radius: 8px;
             }
             .card-image {
-                background: #1a1a1a;
+                background: transparent;
             }
             .card-image.placeholder {
                 border-color: rgba(255,255,255,0.15);


### PR DESCRIPTION
## Summary
- Instead of hardcoding a dark color for card image backgrounds, use `transparent` so the card's own background shows through
- Empty space around card images now blends naturally with the card surface (works for both regular and owned card states)

## Test plan
- [ ] JMU page: card image empty space matches card background, not a separate color