### PR TITLE
Use transparent image background in both themes

### DIFF
--- a/checklist-engine.js
+++ b/checklist-engine.js
@@ -344,11 +344,7 @@ class ChecklistEngine {
             }
             .player-name { color: ${textColor}; }
             .card-image-wrapper {
-                background: transparent;
                 border-radius: 8px;
-            }
-            .card-image {
-                background: transparent;
             }
             .card-image.placeholder {
                 border-color: rgba(255,255,255,0.15);

--- a/shared.css
+++ b/shared.css
@@ -730,7 +730,7 @@ select, input[type="text"] {
     width: 100%;
     padding-top: 140%;
     margin-bottom: 8px;
-    background: #f0f0f0;
+    background: transparent;
     border-radius: var(--radius-sm);
     overflow: hidden;
 }
@@ -742,7 +742,7 @@ select, input[type="text"] {
     width: 100%;
     height: 100%;
     object-fit: contain;
-    background: #fafafa;
+    background: transparent;
     cursor: pointer;
 }
 


### PR DESCRIPTION
## Summary
- Move transparent background to shared.css base styles instead of only dark theme
- Card image empty space blends with card surface in both light and dark themes
- Remove now-redundant dark theme overrides in checklist-engine.js

## Test plan
- [ ] JMU (dark theme): image empty space blends with card
- [ ] Jayden Daniels (light theme): image empty space blends with card