### PR TITLE
Stop hiding Base variants in config-driven engine

### DIFF
--- a/checklist-engine.js
+++ b/checklist-engine.js
@@ -578,9 +578,9 @@ class ChecklistEngine {
         const scpUrl = CardRenderer.getScpUrl(priceSearchTerm);
         const thresholds = this.getPriceThresholds();
 
-        // Clean up type/variant display
+        // Clean up type display
         const displayType = (card.type || '').replace(/\s*RC\b/gi, '').replace(/\bBase\b/gi, '').trim();
-        const displayVariant = (card.variant && card.variant !== 'Base') ? card.variant : '';
+        const displayVariant = card.variant || '';
 
         // Collection link cards (special type)
         if (card.collectionLink) {


### PR DESCRIPTION
## Summary
- Stop silently filtering `variant="Base"` from card display in the engine
- If a variant value shouldn't show, the data should be cleaned instead of hidden

## Data cleanup
After merge, run `scripts/cleanup-jd-variants.js` in browser console to remove stale `variant: "Base"` values from JD card data in the gist.

## Test plan
Preview: https://fix-variant-display-and-clea.sports-card-checklists.pages.dev

- [ ] Cards with real variants (e.g. "Silver Prizm") still display correctly
- [ ] After data cleanup, cards that had "Base" variant show no variant text