### PR TITLE
Fix crash when canceling card editor

### DIFF
--- a/shared.js
+++ b/shared.js
@@ -1952,6 +1952,7 @@ class ImageEditorModal {
 
     // Close modal
     close() {
+        if (!this.backdrop) return;
         this.backdrop.classList.remove('active');
         if (this.cropper) {
             this.cropper.destroy();


### PR DESCRIPTION
## Summary
- Fix `TypeError: Cannot read properties of null` when closing the card editor
- `CardEditorModal.close()` always calls `imageEditor.close()`, but the image editor's backdrop DOM hasn't been created yet if it was never opened
- Add null guard in `ImageEditorModal.close()`

## Test plan
- [ ] Open card editor, hit Cancel - no console error
- [ ] Open card editor, edit image, close editor - still works