### PR TITLE
Fix collection link card: navigation, card stack, and stats

### DIFF
--- a/shared.css
+++ b/shared.css
@@ -725,6 +725,56 @@ select, input[type="text"] {
     border-color: var(--card-owned-border);
 }
 
+/* Collection link cards (cross-checklist promo cards) */
+.card.collection-link { cursor: pointer; }
+.card.collection-link .card-stack {
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+}
+.card.collection-link .card-stack img {
+    position: absolute;
+    width: 70%;
+    height: auto;
+    object-fit: contain;
+    border-radius: 4px;
+    box-shadow: 0 4px 15px rgba(0,0,0,0.5);
+}
+.card.collection-link .card-stack img:nth-child(1) { transform: rotate(-8deg) translateX(-15%); opacity: 0.7; }
+.card.collection-link .card-stack img:nth-child(2) { transform: rotate(5deg) translateX(15%); opacity: 0.85; }
+.card.collection-link .card-stack img:nth-child(3) { transform: rotate(0deg); z-index: 2; }
+.collection-badge {
+    position: absolute;
+    top: 8px;
+    right: 8px;
+    background: linear-gradient(135deg, var(--color-accent, #667eea), var(--color-primary, #667eea));
+    color: #000;
+    padding: 4px 10px;
+    border-radius: 20px;
+    font-size: 0.8em;
+    font-weight: bold;
+    z-index: 3;
+}
+.collection-cta {
+    display: block;
+    text-align: center;
+    background: linear-gradient(135deg, var(--color-accent, #667eea), var(--color-primary, #667eea));
+    color: #000;
+    padding: 8px 12px;
+    border-radius: 6px;
+    font-weight: bold;
+    font-size: 0.85em;
+    margin-top: 8px;
+    text-decoration: none;
+    transition: transform 0.2s;
+}
+.collection-cta:hover { transform: scale(1.02); }
+
 .card-image-wrapper {
     position: relative;
     width: 100%;


### PR DESCRIPTION
## Summary
- **Fix navigation bug**: `sanitizeUrl()` rejects relative URLs like `checklist.html?id=jayden-daniels`, returning empty string. The CTA button was navigating to the current page instead of the linked checklist. Now uses `sanitizeText()` for internal relative links.
- **Card stack support**: New `stackImages` array on collection link cards renders a fanned 3-card stack (same look as the legacy page). Falls back to single `img` if not set.
- **Linked checklist stats**: Badge now shows "X / Y CARDS" (owned/total) loaded from the linked checklist's gist stats, instead of just a static `cardCount`.
- **Shared styles**: Moved collection link card CSS (`.card-stack`, `.collection-badge`, `.collection-cta`) to `shared.css` for reuse across checklists.

## Test plan
- [ ] Run `fix-collection-link-card.js` script to add stackImages to WQBs card data
- [ ] CTA button ("View Full Collection") navigates to Jayden Daniels page
- [ ] Clicking card area also navigates to Jayden Daniels page
- [ ] Card stack shows 3 fanned JD card images
- [ ] Badge shows owned/total (e.g., "15 / 42 CARDS")