### PR TITLE
Fix CORS error when editing R2 images

### DIFF
--- a/shared.js
+++ b/shared.js
@@ -1582,9 +1582,11 @@ class ImageEditorModal {
         if (input) input.value = '0°';
 
         // Set image source (crossOrigin needed for R2 images so canvas isn't tainted)
+        // Cache-bust to avoid browser serving a cached non-CORS response from the
+        // regular <img> tag that loaded the same URL without crossOrigin
         const img = this.backdrop.querySelector('#image-editor-img');
         img.crossOrigin = 'anonymous';
-        img.src = imageSrc;
+        img.src = imageSrc + (imageSrc.includes('?') ? '&' : '?') + '_cb=1';
 
         // Show modal
         this.backdrop.classList.add('active');


### PR DESCRIPTION
## Summary
- Fix image editor failing with CORS error when editing existing R2-hosted card images
- Browser caches images loaded by regular `<img>` tags without CORS headers; when ImageEditorModal loads the same URL with `crossOrigin='anonymous'`, the cached non-CORS response is reused
- Cache-bust param (`_cb=1`) forces a fresh request that includes proper CORS headers

## Test plan
- [ ] Open JD checklist, right-click a card with an R2 image, click "Edit Image"
- [ ] Image editor opens without CORS error
- [ ] Crop/edit and save works correctly