### PR TITLE
Only cache-bust http URLs in image editor

### DIFF
--- a/shared.js
+++ b/shared.js
@@ -1582,11 +1582,12 @@ class ImageEditorModal {
         if (input) input.value = '0°';
 
         // Set image source (crossOrigin needed for R2 images so canvas isn't tainted)
-        // Cache-bust to avoid browser serving a cached non-CORS response from the
-        // regular <img> tag that loaded the same URL without crossOrigin
+        // Cache-bust http(s) URLs to avoid browser serving a cached non-CORS response
+        // from the regular <img> tag that loaded the same URL without crossOrigin
         const img = this.backdrop.querySelector('#image-editor-img');
         img.crossOrigin = 'anonymous';
-        img.src = imageSrc + (imageSrc.includes('?') ? '&' : '?') + '_cb=1';
+        const isHttpUrl = imageSrc.startsWith('http');
+        img.src = isHttpUrl ? imageSrc + (imageSrc.includes('?') ? '&' : '?') + '_cb=1' : imageSrc;
 
         // Show modal
         this.backdrop.classList.add('active');


### PR DESCRIPTION
## Summary
- Fix from #495 appended `_cb=1` to ALL URLs including `data:` URLs, making them invalid (`ERR_INVALID_URL`)
- Now only cache-busts `http(s)` URLs where the browser cache CORS mismatch actually occurs

## Test plan
- [ ] Edit an existing R2-hosted card image (right-click > Edit Image) - no CORS error
- [ ] Process a new image from eBay URL - no ERR_INVALID_URL on the data URL step
- [ ] Upload a local file via drag-and-drop - editor opens and saves correctly