### PR TITLE
Fix collapsible sections never expanding

### DIFF
--- a/checklist-engine.js
+++ b/checklist-engine.js
@@ -105,7 +105,6 @@ class ChecklistEngine {
         this.cardContextMenu.init();
         this.cardEditor.init();
         this.renderCards();
-        CollapsibleSections.init({ persist: true, storageKey: `${this.id}-collapsed` });
     }
 
     // ========================================


### PR DESCRIPTION
## Summary
- `renderCards()` already calls `CollapsibleSections.init()` at the end
- The engine's `init()` method called it a second time immediately after `renderCards()`
- This added duplicate click handlers: header toggled collapsed twice (on then off = no change), wrapper stayed collapsed
- Removed the duplicate call - one-line fix

## Test plan
- [ ] WQBs page: collapse a section, click to expand - it expands
- [ ] JD/JMU pages: same test (they also use renderCards → init flow)
- [ ] Collapsed state persists across page reload