### PR TITLE
Clean up empty custom field values when saving cards

### DIFF
--- a/checklist-engine.js
+++ b/checklist-engine.js
@@ -1325,6 +1325,7 @@ class ChecklistEngine {
             ['price', 'img', 'auto', 'rc', 'patch', 'serial', 'variant'].forEach(key => {
                 if (!(key in cardData) || !cardData[key]) delete card[key];
             });
+            this._cleanupCustomFields(card, cardData);
             // Re-sort
             this.cards.splice(found.index, 1);
             this._insertCardSorted(this.cards, card);
@@ -1339,10 +1340,20 @@ class ChecklistEngine {
             ['price', 'img', 'auto', 'rc', 'patch', 'serial', 'variant'].forEach(key => {
                 if (!(key in cardData) || !cardData[key]) delete card[key];
             });
+            this._cleanupCustomFields(card, cardData);
             // Remove from old category, insert into new
             this.cards[oldCategory].splice(index, 1);
             if (!this.cards[newCategory]) this.cards[newCategory] = [];
             this._insertCardSorted(this.cards[newCategory], card);
+        }
+    }
+
+    // Remove empty-string custom text fields from saved card data
+    _cleanupCustomFields(card, cardData) {
+        const customFields = this.config.customFields || {};
+        for (const [key, config] of Object.entries(customFields)) {
+            if (config.type === 'checkbox') continue;
+            if (key in cardData && !cardData[key]) delete card[key];
         }
     }
 


### PR DESCRIPTION
## Summary
- Empty custom text fields (like `achievement`) were saved as `""` to gist data, causing empty gold pills to render
- The existing cleanup in `_updateCard` only covered hardcoded fields (`price`, `img`, `auto`, etc.)
- Added `_cleanupCustomFields()` that removes empty-string custom text fields from card data before saving

## Test plan
- [ ] Edit a WQBs card with no achievement, save - no empty `achievement: ""` in data
- [ ] Edit a card WITH an achievement, clear it, save - achievement is removed
- [ ] Edit a card with achievement, keep it, save - achievement preserved