### PR TITLE
Remove super-bowl card background styling

### DIFF
--- a/checklist-engine.js
+++ b/checklist-engine.js
@@ -615,7 +615,7 @@ class ChecklistEngine {
             return this._renderCollectionLinkCard(card);
         }
 
-        const cardClass = `card ${owned ? 'owned' : ''} ${card.superBowl ? 'super-bowl' : ''}`.trim();
+        const cardClass = `card ${owned ? 'owned' : ''}`.trim();
 
         let html = `<div class="${cardClass}" data-price="${price}"${card.sport ? ` data-sport="${card.sport}"` : ''}${card.era ? ` data-era="${card.era}"` : ''} data-type="${card.type || ''}">`;
         html += `<div class="card-image-wrapper">`;


### PR DESCRIPTION
## Summary
- Super Bowl winner cards had a different background tint (`rgba(255,215,0,0.1)` unowned, `rgba(39,174,96,0.2)` owned) via a `super-bowl` CSS class
- Removed the class from engine rendering so all cards look the same
- The `superbowl` sort option and `card.superBowl` data field are preserved for sorting
- Migration script also updated to strip the super-bowl CSS from the gist config

## Test plan
- [ ] WQBs page: Mark Rypien cards look the same as Cary Conklin cards when owned
- [ ] Sort by Super Bowl Winners still works