### PR TITLE
Use WebP compression for image editor output

### DIFF
--- a/shared.js
+++ b/shared.js
@@ -1646,7 +1646,7 @@ class ImageEditorModal {
 
             // Convert to data URL
             console.log('ImageEditor: Converting to data URL...');
-            const dataUrl = canvas.toDataURL('image/png');
+            const dataUrl = canvas.toDataURL('image/webp', 0.85);
             console.log('ImageEditor: Data URL length:', dataUrl?.length);
 
             // Save resolve function before close() clears it


### PR DESCRIPTION
## Summary
- Image editor was outputting PNG from the crop canvas, producing ~2.4MB files for typical card images
- This exceeded the R2 upload limit (2MB), causing 413 errors
- Changed to WebP at 0.85 quality, matching the format ImageProcessor already uses

## Test plan
- [ ] Open a card with an existing image
- [ ] Click edit (crop) on the image
- [ ] Crop and confirm - should upload successfully without 413 error