### PR TITLE
Fix URL input overflow in image section

### DIFF
--- a/shared.css
+++ b/shared.css
@@ -1697,6 +1697,7 @@ select, input[type="text"] {
 
 .card-editor-image-url-row .card-editor-input {
     flex: 1;
+    min-width: 0;
 }
 
 /* Upload zone */


### PR DESCRIPTION
## Summary
- Add `min-width: 0` to the URL input in the image tab to prevent long URLs from blowing out the flex container

## Test plan
- [ ] Paste a long URL - input stays within modal bounds