### PR TITLE
Fix image section overflow

### DIFF
--- a/shared.css
+++ b/shared.css
@@ -1652,6 +1652,8 @@ select, input[type="text"] {
     margin-top: 4px;
     padding-top: 12px;
     border-top: 1px solid rgba(255, 255, 255, 0.05);
+    min-width: 0;
+    overflow: hidden;
 }
 
 /* Image tabs */


### PR DESCRIPTION
## Summary
- Add `min-width: 0` and `overflow: hidden` to `.card-editor-image-section` to prevent grid item from exceeding container width
- Root cause: grid items default to `min-width: auto`, allowing content to push wider than the grid column

## Test plan
- [ ] Open editor with a card that has a long URL - modal stays within bounds