### PR TITLE
Fix editor body horizontal overflow

### DIFF
--- a/shared.css
+++ b/shared.css
@@ -1413,6 +1413,7 @@ select, input[type="text"] {
     padding: 20px 24px;
     max-height: 60vh;
     overflow-y: auto;
+    overflow-x: hidden;
 }
 
 .card-editor-body::-webkit-scrollbar {
@@ -1439,6 +1440,7 @@ select, input[type="text"] {
     display: flex;
     flex-direction: column;
     gap: 6px;
+    min-width: 0;
 }
 
 .card-editor-field.full-width {


### PR DESCRIPTION
## Summary
- Add `overflow-x: hidden` to `.card-editor-body` on desktop (mobile already had it)
- Add `min-width: 0` to `.card-editor-field` so grid items can't push wider than their columns

## Test plan
- [ ] Open editor - no horizontal scrollbar, all content stays within modal bounds