### PR TITLE
Include player name in search terms for single-player checklists

### DIFF
--- a/checklist-engine.js
+++ b/checklist-engine.js
@@ -595,7 +595,7 @@ class ChecklistEngine {
         const owned = cardId ? this.isOwned(cardId) : false;
         const price = this.getPrice(card);
         const showPlayer = this.config.cardDisplay?.showPlayerName !== false && card.player;
-        const playerForSearch = showPlayer ? card.player + ' ' : '';
+        const playerForSearch = card.player ? card.player + ' ' : '';
         const defaultSearch = encodeURIComponent(`${playerForSearch}${card.set} ${card.num}`);
         const searchUrl = CardRenderer.getEbayUrl(card.search || defaultSearch);
         const priceSearchTerm = card.priceSearch || defaultSearch;


### PR DESCRIPTION
## Summary
- Search terms (eBay/SCP) now always include `card.player` when available
- Previously, `showPlayerName: false` (used for single-player checklists like Jayden Daniels) also suppressed the player name from search URLs
- Display logic and search logic are now independent

## Test plan
- [ ] Jayden Daniels cards have "Jayden Daniels" in eBay/SCP search links
- [ ] Multi-player checklists still include player names in searches