### PR TITLE
Default show player names to on for new checklists

### DIFF
--- a/shared.js
+++ b/shared.js
@@ -3916,7 +3916,7 @@ class ChecklistCreatorModal {
         this.backdrop.querySelector('#creator-accent-hex').textContent = '#f39c12';
         this.backdrop.querySelector('#creator-dark-theme').checked = false;
         this.backdrop.querySelector('#creator-use-sections').checked = true;
-        this.backdrop.querySelector('#creator-show-player').checked = false;
+        this.backdrop.querySelector('#creator-show-player').checked = true;
         this.backdrop.querySelector('#creator-description').value = '';
 
         // Reset attribute checkboxes to checked


### PR DESCRIPTION
## Summary
- Checklist creator now defaults "Show player names" checkbox to checked
- Previously defaulted to unchecked, which is only appropriate for single-player checklists

## Test plan
- [ ] Open checklist creator - "Show player names" is checked by default
- [ ] Editing an existing checklist still loads its saved value correctly