### PR TITLE
Deduplicate sort dropdown when defaultSortMode is set

### DIFF
--- a/checklist-engine.js
+++ b/checklist-engine.js
@@ -715,7 +715,12 @@ class ChecklistEngine {
 
     _renderFilters() {
         const container = document.getElementById('filters-container');
-        const sorts = this.config.sortOptions || ['default', 'year', 'set', 'price-low', 'price-high', 'owned', 'needed'];
+        let sorts = this.config.sortOptions || ['default', 'year', 'set', 'price-low', 'price-high', 'owned', 'needed'];
+        const defaultSort = this.config.defaultSortMode;
+        // Remove the defaultSortMode from the list since "Default" already applies it
+        if (defaultSort) {
+            sorts = sorts.filter(s => s !== defaultSort);
+        }
         const customFilters = this.config.customFilters || [];
 
         let html = '';
@@ -760,8 +765,15 @@ class ChecklistEngine {
     }
 
     _getSortLabel(key) {
+        if (key === 'default') {
+            const ds = this.config.defaultSortMode;
+            if (ds) {
+                const inner = this._getSortLabel(ds).replace('Sort: ', '');
+                return `Sort: ${inner} (Default)`;
+            }
+            return 'Sort: Default';
+        }
         const labels = {
-            'default': 'Sort: Default',
             'year': 'Sort: Year',
             'set': 'Sort: Set/Brand',
             'price-low': 'Sort: Price (Low to High)',


### PR DESCRIPTION
## Summary
- When `defaultSortMode` matches a sort option (e.g. both "Default" and "Year" sort by year), the duplicate is removed from the dropdown
- "Default" label now shows what it does: e.g. "Sort: Year (Default)" instead of just "Sort: Default"
- Checklists without `defaultSortMode` are unaffected

## Test plan
- [ ] Checklist with `defaultSortMode: 'year'` shows "Sort: Year (Default)" and no separate "Year" option
- [ ] Checklist without `defaultSortMode` shows "Sort: Default" as before
- [ ] All other sort options still work