### PR TITLE
Preserve owned status when card edits change the ID

### DIFF
--- a/checklist-engine.js
+++ b/checklist-engine.js
@@ -1250,15 +1250,20 @@ class ChecklistEngine {
                 this.updateStats();
             },
             onSave: async (cardId, cardData, isNew) => {
+                const newId = this.getCardId(cardData);
                 if (isNew) {
                     this._addCard(cardData);
                 } else {
+                    // Transfer owned status if card ID changed (e.g. variant/set/num edit)
+                    if (cardId !== newId && this.checklistManager.isOwned(cardId)) {
+                        this.checklistManager.toggleOwned(cardId, false);
+                        this.checklistManager.toggleOwned(newId, true);
+                    }
                     this._updateCard(cardId, cardData);
                 }
                 this.renderCards();
                 this.updateStats();
                 // Scroll to the card
-                const newId = this.getCardId(cardData);
                 const cardEl = document.querySelector(`.card[data-id="${newId}"]`);
                 if (cardEl) {
                     cardEl.scrollIntoView({ behavior: 'smooth', block: 'center' });


### PR DESCRIPTION
## Summary
- Card IDs are derived from `set + num + variant`, so editing any of those fields generates a new ID
- Previously this orphaned the owned status - the card appeared unowned after the edit
- Now transfers owned status from old ID to new ID when an edit changes the card ID

## Test plan
- [ ] Mark a card as owned, change its variant - card stays owned
- [ ] Mark a card as owned, change its set name - card stays owned
- [ ] Mark a card as owned, change its number - card stays owned
- [ ] Unowned card edited - stays unowned (no false positive)
- [ ] New card added - not affected by this change