### PR TITLE
Shrink advanced toggle button to text width

### DIFF
--- a/shared.css
+++ b/shared.css
@@ -1456,7 +1456,6 @@ select, input[type="text"] {
 
 .card-editor-advanced-toggle .card-editor-toggle-btn {
     padding: 12px 14px;
-    width: 100%;
     text-align: center;
 }
 


### PR DESCRIPTION
## Summary
- Removed `width: 100%` from the Advanced toggle button in the card editor
- Button is now only clickable on the text itself, not the full editor width

## Test plan
- [ ] Advanced button click target matches its visible text