### PR TITLE
Add save failure handling with retry and error banners

### DIFF
--- a/shared.css
+++ b/shared.css
@@ -450,6 +450,40 @@ h1 {
 .sync-status.synced { color: var(--color-sync-synced); }
 .sync-status.error { color: var(--color-sync-error); }
 
+.save-error-banner {
+    position: fixed;
+    top: 0;
+    left: 0;
+    right: 0;
+    z-index: 10000;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 12px;
+    padding: 12px 16px;
+    background: #d32f2f;
+    color: #fff;
+    font-family: 'Barlow', sans-serif;
+    font-size: 0.9em;
+    font-weight: 500;
+    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.3);
+}
+
+.save-error-banner button {
+    background: none;
+    border: none;
+    color: #fff;
+    font-size: 1.4em;
+    cursor: pointer;
+    padding: 0 4px;
+    line-height: 1;
+    opacity: 0.8;
+}
+
+.save-error-banner button:hover {
+    opacity: 1;
+}
+
 .read-only-notice {
     font-family: 'Barlow', sans-serif;
     background: rgba(255, 182, 18, 0.2);

--- a/shared.js
+++ b/shared.js
@@ -3022,14 +3022,11 @@ class CardEditorModal {
             data.search = this.generateSearchTerm(data.set, data.num, data.variant, data.player);
         }
 
-        if (this.isNewCard) {
-            this.onSave(null, data, true);
-        } else {
-            this.onSave(this.currentCardId, data, false);
-        }
+        // Close editor first so user sees the card update immediately
+        this.setDirty(false);
+        this.backdrop.classList.remove('active');
 
-        // Handle owned state change - always pass data so handler can compute
-        // the post-save card ID (card ID changes when data changes)
+        // Handle owned state change
         if (this.onOwnedChange) {
             const nowOwned = this.backdrop.querySelector('#editor-owned').checked;
             if (nowOwned !== this._initialOwned) {
@@ -3037,8 +3034,12 @@ class CardEditorModal {
             }
         }
 
-        this.setDirty(false);
-        this.backdrop.classList.remove('active');
+        // Fire save (awaited so errors propagate to the async chain)
+        if (this.isNewCard) {
+            await this.onSave(null, data, true);
+        } else {
+            await this.onSave(this.currentCardId, data, false);
+        }
     }
 
     // Delete card


### PR DESCRIPTION
## Summary
- `saveCardData` now returns `{ ok, reason }` instead of a boolean, with reasons: `not_authenticated`, `auth_expired`, `api_error`, `network_error`
- Automatic retry (once, after 1.5s) for transient failures (skipped for auth errors since retrying won't help)
- Dismissible red error banner at page top for expired sessions ("sign out and back in") and generic failures ("changes still in memory")
- Card editor now awaits `onSave` so async save errors propagate instead of being silently swallowed

Closes #522

## Test plan
- [ ] Edit a card and save - verify normal save still works
- [ ] Simulate expired token (manually clear token from localStorage, then save) - verify "session expired" banner appears
- [ ] Dismiss the error banner with the X button
- [ ] Verify banner doesn't stack (only one at a time)