### PR TITLE
Update docs, rules, and add search term tests

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -3,6 +3,12 @@
 ## Card Selection
 - **Avoid print-on-demand cards** - Generally don't add Topps Now or Panini Instant cards. Exception: players with very limited card options where this is their only/best card.
 
+## Architecture
+- **All checklists are config-driven** - `checklist.html` + `checklist-engine.js` loads config from gist via `?id=xxx`
+- **No per-checklist HTML files** - Checklists are added via gist registry, not by creating new HTML pages
+- Config stored in gist: `checklists-registry.json`, `{id}-config.json`, `{id}-cards.json`
+- Images stored in Cloudflare R2, served via Worker - no git-based image flow
+
 ## Data Storage
 - **The GitHub Gist is the source of truth** for all collection data (owned cards, stats)
 - Never use localStorage as the primary data source - it won't work for online visitors
@@ -14,8 +20,12 @@
 - Skip local preview for most changes; test on the live site after merge
 - GitHub Pages deploys in ~30-60 seconds after push
 - After a PR is merged, wait for user to test before pushing more fixes - create new PRs instead of adding to old branches
+- **Unit tests** - Run `npm test` (vitest). Tests cover sanitize, CardRenderer, and CardEditorModal search term generation.
 - **Preview gist sync** - Before testing on Cloudflare preview sites, remind user to sync preview gist from production (login on preview site, use "Sync from Production" button). Otherwise data may be stale or have outdated schema.
-- **Preview URL format** - Cloudflare Pages converts branch names: slashes become dashes, then truncated to exactly 28 characters. Count AFTER converting slashes. Example: `fix/consolidate-search-toggles` → `fix-consolidate-search-toggles` (30 chars) → truncate to `fix-consolidate-search-toggl` (28 chars) → `https://fix-consolidate-search-toggl.sports-card-checklists.pages.dev`
+- **Preview URL format** - Cloudflare Pages converts branch names: slashes become dashes, then truncated to exactly 28 characters. Count AFTER converting slashes. Example: `fix/consolidate-search-toggles` -> `fix-consolidate-search-toggles` (30 chars) -> truncate to `fix-consolidate-search-toggl` (28 chars) -> `https://fix-consolidate-search-toggl.sports-card-checklists.pages.dev`
+
+## Pull Requests
+- **Never force-merge with `--admin`** - Let CI checks run and merge only after they pass
 
 ## Consistency
 - When making changes to a page or card component, consider applying the same change to all checklists/cards

--- a/tests/search-term.test.js
+++ b/tests/search-term.test.js
@@ -1,0 +1,72 @@
+import { describe, it, expect } from 'vitest';
+
+const CardEditorModal = globalThis.CardEditorModal;
+
+// Helper: create a minimal editor instance to test generateSearchTerm
+function makeEditor(playerName = '') {
+    const editor = Object.create(CardEditorModal.prototype);
+    editor.playerName = playerName;
+    return editor;
+}
+
+describe('CardEditorModal.generateSearchTerm', () => {
+    it('combines player, set, number, and variant', () => {
+        const editor = makeEditor('Jayden Daniels');
+        const result = editor.generateSearchTerm('2024 Donruss', '#101', 'Silver', null);
+        expect(result).toBe('jayden+daniels+2024+donruss+101+silver');
+    });
+
+    it('uses card-level player over default playerName', () => {
+        const editor = makeEditor('Default Player');
+        const result = editor.generateSearchTerm('2024 Donruss', null, null, 'Jayden Daniels');
+        expect(result).toBe('jayden+daniels+2024+donruss');
+    });
+
+    it('falls back to playerName when no card player', () => {
+        const editor = makeEditor('Jayden Daniels');
+        const result = editor.generateSearchTerm('2024 Donruss', null, null, null);
+        expect(result).toBe('jayden+daniels+2024+donruss');
+    });
+
+    it('strips # prefix from card number', () => {
+        const editor = makeEditor('Player');
+        const result = editor.generateSearchTerm('Set', '#42', null, null);
+        expect(result).toBe('player+set+42');
+    });
+
+    it('excludes Base variant', () => {
+        const editor = makeEditor('Player');
+        const result = editor.generateSearchTerm('Set', null, 'Base', null);
+        expect(result).toBe('player+set');
+    });
+
+    it('includes non-Base variant', () => {
+        const editor = makeEditor('Player');
+        const result = editor.generateSearchTerm('Set', null, 'Silver Prizm', null);
+        expect(result).toBe('player+set+silver+prizm');
+    });
+
+    it('works with no playerName and no card player', () => {
+        const editor = makeEditor('');
+        const result = editor.generateSearchTerm('2024 Donruss', '#5', null, null);
+        expect(result).toBe('2024+donruss+5');
+    });
+
+    it('lowercases everything and replaces spaces with +', () => {
+        const editor = makeEditor('JAYDEN DANIELS');
+        const result = editor.generateSearchTerm('2024 Panini Prizm', null, null, null);
+        expect(result).toBe('jayden+daniels+2024+panini+prizm');
+    });
+
+    it('handles all empty inputs', () => {
+        const editor = makeEditor('');
+        const result = editor.generateSearchTerm('', null, null, null);
+        expect(result).toBe('');
+    });
+
+    it('handles only set name', () => {
+        const editor = makeEditor('');
+        const result = editor.generateSearchTerm('2024 Topps Chrome', null, null, null);
+        expect(result).toBe('2024+topps+chrome');
+    });
+});


### PR DESCRIPTION
## Summary
- **CLAUDE.md**: Added Architecture section (config-driven, R2), no-admin-merge rule, unit test mention. Removed stale PriceUtils reference.
- **README**: Removed price estimation features, updated architecture diagram to show config-driven flow, updated key components table, rewrote "Adding New Checklists" for gist-based workflow, added Running Tests section, updated image editor description to tab-based UI.
- **Tests**: Added `search-term.test.js` with 10 tests for `CardEditorModal.generateSearchTerm` (player fallback, # stripping, Base variant exclusion, lowercasing, empty inputs). Total: 59 tests across 3 files.

## Test plan
- [ ] `npm test` passes (59 tests, 3 files)
- [ ] README renders correctly on GitHub