### PR TITLE
Fall back to public gist when auth token expires

### DIFF
--- a/github-sync.js
+++ b/github-sync.js
@@ -872,6 +872,15 @@ class GitHubSync {
         return this._readGistFile(`${checklistId}-cards.json`);
     }
 
+    // Load config from public gist (fallback when auth fails)
+    async loadPublicChecklistConfig(checklistId) {
+        const filename = `${checklistId}-config.json`;
+        const gist = await this._fetchGist(true);
+        if (!gist) return null;
+        const content = gist.files[filename]?.content;
+        return content ? JSON.parse(content) : null;
+    }
+
     // Load card data from public gist (fallback, or for non-logged-in users)
     async loadPublicCardData(checklistId) {
         const filename = `${checklistId}-cards.json`;

--- a/shared.css
+++ b/shared.css
@@ -484,6 +484,15 @@ h1 {
     opacity: 1;
 }
 
+.save-error-banner .save-error-action {
+    font-size: 0.9em;
+    font-weight: 600;
+    padding: 4px 12px;
+    border: 1px solid rgba(255, 255, 255, 0.6);
+    border-radius: 4px;
+    white-space: nowrap;
+}
+
 .read-only-notice {
     font-family: 'Barlow', sans-serif;
     background: rgba(255, 182, 18, 0.2);


### PR DESCRIPTION
## Summary
- **Root cause**: When a user's GitHub token expires, `_loadConfig()` tried only the authenticated gist fetch, got a 403, returned null, and threw "config not found" - showing a blank page. Card data loading already had a public fallback, but config loading did not.
- **Fix**: `_loadConfig()` now falls back to `loadPublicChecklistConfig()` (new method) when the authenticated fetch fails. The page loads in read-only mode instead of breaking entirely.
- **Sign Out button**: The "session expired" error banner now includes a Sign Out action button so users can re-authenticate without hunting through the menu.

## Test plan
- [ ] Sign in, then manually expire the token (clear `github_token` from localStorage, set it to `bad_token`, or wait for natural expiry)
- [ ] Navigate to a checklist - should load cards in read-only mode instead of blank page
- [ ] Attempt to save a card - error banner appears with "Sign Out" button
- [ ] Click Sign Out - logs out and reloads the page
- [ ] Dismiss banner with X button still works