### PR TITLE
Fix expired token fallback for index page and all gist reads

### DIFF
--- a/github-sync.js
+++ b/github-sync.js
@@ -344,6 +344,10 @@ class GitHubSync {
                 headers: { 'Authorization': `Bearer ${this.token}` },
             });
 
+            // If auth failed, fall back to public data
+            if (!response.ok && (response.status === 401 || response.status === 403)) {
+                return this.loadPublicData();
+            }
             if (!response.ok) return null;
 
             const gist = await response.json();
@@ -610,6 +614,10 @@ class GitHubSync {
                 response = await fetch(`https://api.github.com/gists/${gistId}`, {
                     headers: { 'Authorization': `Bearer ${this.token}` },
                 });
+                // If auth failed, fall back to public gist
+                if (!response.ok && (response.status === 401 || response.status === 403)) {
+                    return this._fetchGist(true);
+                }
             } else {
                 response = await fetch(`https://api.github.com/gists/${CONFIG.PUBLIC_GIST_ID}`);
             }


### PR DESCRIPTION
## Summary
Previous fix (#527) only covered `_loadConfig` in checklist-engine.js. The index page, DynamicNav registry loading, and `loadData()` all had the same problem: an expired token causes a 403 on the authenticated gist fetch with no fallback.

**Root fix**: `_fetchGist()` now falls back to the public gist on 401/403, and `loadData()` falls back to `loadPublicData()`. This covers all callers at the source without needing per-caller fallbacks.

## Test plan
- [ ] Set `github_token` to `bad_token` in localStorage
- [ ] Load the index page - all checklist cards should still render with stats
- [ ] Load a checklist page (e.g. `?id=personal-favorites`) - cards should load in read-only mode
- [ ] Sign out and back in - full read/write access restored