### PR TITLE
Preserve registry colors and extraPills when editing settings

### DIFF
--- a/shared.js
+++ b/shared.js
@@ -4174,9 +4174,17 @@ class ChecklistCreatorModal {
                             entry.title = config.title;
                             entry.navLabel = config.navLabel;
                             entry.description = config.indexCard?.description || '';
-                            entry.accentColor = config.theme?.accentColor || config.theme?.primaryColor || '#667eea';
-                            entry.borderColor = config.theme?.primaryColor || '#667eea';
-                            entry.extraPills = extraPills.length > 0 ? extraPills : undefined;
+                            // Only update colors if theme was explicitly set (not defaults)
+                            if (config.theme?.accentColor && config.theme.accentColor !== '#667eea') {
+                                entry.accentColor = config.theme.accentColor;
+                            }
+                            if (config.theme?.primaryColor && config.theme.primaryColor !== '#667eea') {
+                                entry.borderColor = config.theme.primaryColor;
+                            }
+                            // Only update extraPills if categories have showOnIndex set
+                            if (extraPills.length > 0) {
+                                entry.extraPills = extraPills;
+                            }
                             await githubSync.saveRegistry(registry);
                         }
                     }


### PR DESCRIPTION
## Summary
The registry update on checklist settings save was clobbering `accentColor`, `borderColor`, and `extraPills` with default values. For checklists migrated before the theme system (like Jayden Daniels), the original gold/maroon colors and insert/premium pills were replaced with grey defaults.

Now only updates these fields when they are explicitly set (non-default colors, non-empty pills), preserving existing registry values.

## Test plan
- [ ] Edit JD checklist settings (e.g. description) and save - colors and extraPills should be preserved in registry
- [ ] Edit a checklist with custom theme colors - colors should update in registry
- [ ] Create a new checklist with extraPills - pills should appear