### PR TITLE
Fix settings save writing to wrong gist file

### DIFF
--- a/checklist-engine.js
+++ b/checklist-engine.js
@@ -195,9 +195,11 @@ class ChecklistEngine {
 
         // Try authenticated gist first, fall back to public gist
         const config = await githubSync.loadChecklistConfig(this.id);
-        if (config) return config;
+        if (config) { config.id = this.id; return config; }
 
-        return githubSync.loadPublicChecklistConfig(this.id);
+        const publicConfig = await githubSync.loadPublicChecklistConfig(this.id);
+        if (publicConfig) publicConfig.id = this.id;
+        return publicConfig;
     }
 
     async _loadCardData() {


### PR DESCRIPTION
## Summary
- Config JSON in the gist doesn't include an `id` field
- When the settings modal reads `existingConfig.id` to build the save filename, it gets `undefined`, so saves go to `undefined-config.json` instead of `washington-all-pros-config.json`
- This is why nav label, description, and title edits were silently lost on all config-driven checklists
- Fix: inject `this.id` (from URL param) into the config object after loading it from the gist
- Evidence: an orphaned `undefined-config.json` file exists in the gist containing the user's attempted settings changes

## Test plan
- [ ] Open Washington Legends checklist settings, change nav label, save
- [ ] Verify nav label updates in the nav bar
- [ ] Verify description changes appear on the index page
- [ ] Clean up orphaned `undefined-config.json` from the gist