### PR TITLE
Fix smart quote crash and cleanup

### DIFF
--- a/shared.css
+++ b/shared.css
@@ -178,10 +178,6 @@ h1 {
     color: #666;
 }
 
-.nav-divider {
-    display: none;
-}
-
 .nav-links {
     display: flex;
     align-items: center;
@@ -503,7 +499,6 @@ h1 {
     }
 
     .nav-brand-text { display: none; }
-    .nav-divider { display: none; }
 
     .nav-dropdown {
         right: -8px;

--- a/tests/sanitize.test.js
+++ b/tests/sanitize.test.js
@@ -59,3 +59,25 @@ describe('sanitizeUrl', () => {
     expect(sanitizeUrl('not a url')).toBe('');
   });
 });
+
+describe('normalizeQuotes', () => {
+  const normalizeQuotes = globalThis.normalizeQuotes;
+
+  it('converts smart single quotes to ASCII', () => {
+    expect(normalizeQuotes('O\u2019Neal')).toBe("O'Neal");
+    expect(normalizeQuotes('\u2018hello\u2019')).toBe("'hello'");
+  });
+
+  it('converts smart double quotes to ASCII', () => {
+    expect(normalizeQuotes('\u201Chello\u201D')).toBe('"hello"');
+  });
+
+  it('passes through regular quotes', () => {
+    expect(normalizeQuotes("O'Neal")).toBe("O'Neal");
+  });
+
+  it('handles null/empty', () => {
+    expect(normalizeQuotes(null)).toBe(null);
+    expect(normalizeQuotes('')).toBe('');
+  });
+});


### PR DESCRIPTION
## Summary
- **Fix: btoa() crash with smart quotes** - iOS keyboards produce curly quotes (U+2019) which btoa() can't handle, crashing card ID generation. Now wraps in encodeURIComponent first. This was preventing cards with names like "O'Neal" from being added on mobile.
- **Normalize smart quotes** - Convert curly single/double quotes to ASCII in all text form fields (set name, player name, custom fields)
- **Cleanup** - Remove unused .nav-divider CSS, update outdated legacy nav comments
- **Tests** - Added normalizeQuotes tests

## Test plan
- [ ] Add a card with an apostrophe in the name (e.g. "O'Neal") from iOS
- [ ] Verify existing Shaquille O'Neal cards still render correctly
- [ ] Smart quotes in any text field get normalized to ASCII on save