### PR TITLE
Show actual sort behavior instead of 'Default'

### DIFF
--- a/checklist-engine.js
+++ b/checklist-engine.js
@@ -817,7 +817,7 @@ class ChecklistEngine {
                 const inner = this._getSortLabel(ds).replace('Sort: ', '');
                 return `Sort: ${inner} (Default)`;
             }
-            return 'Sort: Default';
+            return 'Sort: As Entered';
         }
         const labels = {
             'year': 'Sort: Year',


### PR DESCRIPTION
## Summary
- When no defaultSortMode is configured, the sort dropdown now shows "Sort: As Entered" instead of the opaque "Sort: Default"
- When a defaultSortMode IS configured, it already showed e.g. "Sort: Year (Default)" which is clear

Closes #443

## Test plan
- [ ] Checklist with no defaultSortMode shows "Sort: As Entered"
- [ ] Checklist with defaultSortMode still shows "Sort: Year (Default)" etc.