### PR TITLE
Capitalize 'Alphabetical' in sort dropdown label

### DIFF
--- a/checklist-engine.js
+++ b/checklist-engine.js
@@ -820,6 +820,7 @@ class ChecklistEngine {
             return 'Sort: As Entered';
         }
         const labels = {
+            'alphabetical': 'Sort: Alphabetical',
             'year': 'Sort: Year',
             'set': 'Sort: Set/Brand',
             'price-low': 'Sort: Price (Low to High)',


### PR DESCRIPTION
## Summary
- Add `alphabetical` to the explicit sort label map so it displays as "Sort: Alphabetical" instead of "Sort: alphabetical"

## Test plan
- [ ] Open a checklist that uses alphabetical as its default sort
- [ ] Verify the sort dropdown shows "Sort: Alphabetical (Default)" with proper casing