### PR TITLE
Fix card ID regression from smart quote fix

### DIFF
--- a/shared.js
+++ b/shared.js
@@ -285,8 +285,11 @@ class ChecklistManager {
         // Allow custom ID field, otherwise generate from set+num+variant
         if (card.id) return card.id;
         const str = (card.set || '') + (card.num || '') + (card.variant || '');
-        // Use encodeURIComponent to handle unicode (btoa only accepts Latin-1)
-        return btoa(encodeURIComponent(str)).replace(/[^a-zA-Z0-9]/g, '');
+        // Replace non-Latin-1 chars (e.g. iOS smart quotes) so btoa doesn't throw.
+        // Must NOT use encodeURIComponent here - that changes the encoding and
+        // breaks all existing stored card IDs.
+        const safe = str.replace(/[^\x00-\xFF]/g, '_');
+        return btoa(safe).replace(/[^a-zA-Z0-9]/g, '');
     }
 
     // Check if current user is the owner


### PR DESCRIPTION
## Summary
- PR #540 changed `getCardId()` from `btoa(str)` to `btoa(encodeURIComponent(str))` to handle iOS smart quotes
- This changed every card ID (spaces became `%20`, `#` became `%23` before base64), so no stored owned-card IDs matched anymore
- **Result: all checklists showed 0 owned cards on production**
- Fix: revert to `btoa(str)` but replace non-Latin-1 characters (like smart quotes) with `_` so btoa doesn't throw

## Test plan
- [ ] Jayden Daniels page shows correct owned cards on production
- [ ] Other checklists show correct owned cards
- [ ] Card with smart quote in set name doesn't crash