### PR TITLE
Add Enter and Escape key support to checklist editor

### DIFF
--- a/shared.js
+++ b/shared.js
@@ -3502,6 +3502,24 @@ class ChecklistCreatorModal {
         backdrop.querySelector('#creator-add-category').onclick = () => this._addCategoryRow();
         backdrop.querySelector('#creator-add-subtitle-line').onclick = () => this._addSubtitleLineRow();
 
+        // Escape key to close
+        document.addEventListener('keydown', (e) => {
+            if (e.key === 'Escape' && backdrop.classList.contains('active')) {
+                this.close();
+            }
+        });
+
+        // Enter key to save (unless in a textarea or while saving)
+        const modal = backdrop.querySelector('.card-editor-modal');
+        modal.addEventListener('keydown', (e) => {
+            if (e.key === 'Enter' && !['TEXTAREA'].includes(e.target.tagName)) {
+                const saveBtn = backdrop.querySelector('#creator-save');
+                if (saveBtn && saveBtn.disabled) return;
+                e.preventDefault();
+                this.save();
+            }
+        });
+
         this.backdrop = backdrop;
         document.body.appendChild(backdrop);
         this._trackDirty();


### PR DESCRIPTION
## Summary
- Enter key saves the checklist settings (matches CardEditorModal behavior)
- Escape key closes the modal
- Enter is blocked during save (disabled button) and from textarea elements

Closes #546

## Test plan
- [ ] Open checklist settings, press Enter - saves
- [ ] Open create checklist, press Enter - creates
- [ ] Press Escape - closes modal
- [ ] Enter while save is in progress - does nothing