### PR TITLE
Use visibility toggling instead of full DOM rebuild on filters

### DIFF
--- a/shared.css
+++ b/shared.css
@@ -820,6 +820,10 @@ select, input[type="text"] {
 /* ============================================
    Card Component
    ============================================ */
+.card.filter-hidden {
+    display: none;
+}
+
 .card {
     border: 1px solid var(--card-border);
     border-radius: var(--radius-md);


### PR DESCRIPTION
## Summary
- When only filters change (search, status, custom), toggle `display` on existing card elements instead of rebuilding the entire DOM
- Full rebuilds still happen on sort changes, ownership toggles, and initial render
- Each card gets a `data-card-idx` attribute mapping to the `_renderedCards` array for fast filter lookups
- Section and group-header visibility auto-updates based on visible children
- CollapsibleSections wrappers preserved during filter-only changes (no re-init needed)

Closes #509

## Test plan
- [ ] Search box filters cards instantly (no flash of empty content)
- [ ] Status filter (owned/needed/all) works correctly
- [ ] Custom filters work correctly (e.g., sport filter on All-Pros)
- [ ] Changing sort still does a full rebuild (verify section structure changes)
- [ ] Switching from non-default sort back to default restores category sections
- [ ] Section headers hide when all cards in section are filtered out
- [ ] Group headers hide when all child sections are hidden
- [ ] Collapsible sections stay collapsed/expanded during filter changes
- [ ] Toggling ownership still updates section progress badges
- [ ] Stats update correctly after filtering
- [ ] Works on both flat (Personal Favorites) and category (Jayden Daniels) checklists