### PR TITLE
Fix card rendering, est. value, image paste, and gist overwrites

### DIFF
--- a/checklist-engine.js
+++ b/checklist-engine.js
@@ -249,6 +249,9 @@ class ChecklistEngine {
     }
 
     async _saveCardData() {
+        // Merge with latest gist data to prevent overwriting external changes (#560)
+        await this._mergeWithFreshGistData();
+
         if (this._isFlat()) {
             this.cardData.cards = this.cards;
         } else {
@@ -278,6 +281,50 @@ class ChecklistEngine {
             this._showSaveError('Save failed. Your changes are still in memory - try refreshing and editing again.');
         }
         return result.ok;
+    }
+
+    // Merge local cards with fresh gist data so external field additions aren't lost
+    async _mergeWithFreshGistData() {
+        try {
+            // Clear cache to get truly fresh data
+            githubSync._gistCache = null;
+            githubSync._publicGistCache = null;
+
+            const freshData = await githubSync.loadCardData(this.id)
+                || await githubSync.loadPublicCardData(this.id);
+            if (!freshData) return;
+
+            const freshCards = this._isFlat() ? freshData.cards : freshData.categories;
+            if (!freshCards) return;
+
+            if (this._isFlat()) {
+                this.cards = this._mergeCardArrays(this.cards, freshCards);
+            } else {
+                for (const catId of Object.keys(this.cards)) {
+                    if (freshCards[catId]) {
+                        this.cards[catId] = this._mergeCardArrays(this.cards[catId], freshCards[catId]);
+                    }
+                }
+            }
+        } catch (e) {
+            // Non-fatal: proceed with save using local data if merge fails
+            console.warn('Failed to merge with fresh gist data:', e);
+        }
+    }
+
+    // Merge two card arrays: fresh fields as base, local fields overlay
+    _mergeCardArrays(localCards, freshCards) {
+        const freshMap = new Map();
+        freshCards.forEach(c => freshMap.set(this.getCardId(c), c));
+
+        return localCards.map(localCard => {
+            const id = this.getCardId(localCard);
+            const freshCard = freshMap.get(id);
+            if (!freshCard) return localCard;
+            // Fresh as base preserves externally-added fields,
+            // local overlay preserves user's in-session edits
+            return { ...freshCard, ...localCard };
+        });
     }
 
     _showSaveError(message, actionLabel, actionFn) {
@@ -696,16 +743,10 @@ class ChecklistEngine {
         }
 
         // Card info (set, number, variant)
-        if (card.years) {
-            // Washington QBs style: set + num on one line
-            html += `<div class="card-info"><span class="card-set">${sanitizeText(card.set)}</span> ${sanitizeText(card.num)}</div>`;
-        } else {
-            // Standard style: set title, number + variant, type
-            if (card.set) html += `<div class="card-title">${sanitizeText(card.set)}</div>`;
-            if (card.num || displayVariant) html += `<div class="card-number">${sanitizeText(card.num)} ${sanitizeText(displayVariant)}</div>`;
-            if (displayType) {
-                html += `<div class="card-type">${sanitizeText(displayType)}</div>`;
-            }
+        if (card.set) html += `<div class="card-title">${sanitizeText(card.set)}</div>`;
+        if (card.num || displayVariant) html += `<div class="card-number">${sanitizeText(card.num)} ${sanitizeText(displayVariant)}</div>`;
+        if (displayType) {
+            html += `<div class="card-type">${sanitizeText(displayType)}</div>`;
         }
 
         // Card actions
@@ -1266,8 +1307,7 @@ class ChecklistEngine {
         StatsAnimator.animateStats({
             owned: { el: document.getElementById('owned-count'), value: stats.owned },
             total: { el: document.getElementById('total-count'), value: stats.total },
-            totalValue: { el: document.getElementById('total-value'), value: stats.ownedValue + stats.neededValue },
-            ownedValue: { el: document.getElementById('owned-value'), value: stats.ownedValue },
+            totalValue: { el: document.getElementById('total-value'), value: stats.ownedValue },
             neededValue: { el: document.getElementById('needed-value'), value: stats.neededValue },
         });
     }

--- a/checklist.html
+++ b/checklist.html
@@ -52,8 +52,7 @@
                     <div class="stat-value highlight" id="total-value">$0</div>
                     <div class="stat-label">Est. Value</div>
                     <div class="stat-breakdown">
-                        <span class="owned-value" id="owned-value">$0 owned</span>
-                        <span class="needed-value" id="needed-value">$0 needed</span>
+                        <span class="needed-value" id="needed-value">$0 to complete</span>
                     </div>
                 </div>
             </div>

--- a/index.html
+++ b/index.html
@@ -397,8 +397,7 @@
                     <div class="aggregate-stat-value highlight" id="agg-value">$0</div>
                     <div class="aggregate-stat-label">Est. Value</div>
                     <div class="aggregate-stat-breakdown">
-                        <span class="owned" id="agg-owned-value">$0 owned</span>
-                        <span class="needed" id="agg-needed-value">$0 needed</span>
+                        <span class="needed" id="agg-needed-value">$0 to complete</span>
                     </div>
                 </div>
             </div>
@@ -453,8 +452,6 @@
             const statsEl = document.getElementById('aggregate-stats');
             statsEl.style.display = 'block';
 
-            const totalValue = totalOwnedValue + totalNeededValue;
-
             if (!hasAnimatedStats) {
                 hasAnimatedStats = true;
                 // Animate the main stats with staggered delays
@@ -465,19 +462,17 @@
                     animateValue(document.getElementById('agg-total'), 0, totalCards, 1200);
                 }, 350);
                 setTimeout(() => {
-                    animateValue(document.getElementById('agg-value'), 0, totalValue, 1400, '$');
+                    animateValue(document.getElementById('agg-value'), 0, totalOwnedValue, 1400, '$');
                 }, 500);
                 setTimeout(() => {
-                    animateValue(document.getElementById('agg-owned-value'), 0, totalOwnedValue, 1000, '$', ' owned');
-                    animateValue(document.getElementById('agg-needed-value'), 0, totalNeededValue, 1000, '$', ' needed');
+                    animateValue(document.getElementById('agg-needed-value'), 0, totalNeededValue, 1000, '$', ' to complete');
                 }, 650);
             } else {
                 // Just update without animation (e.g., when data changes)
                 document.getElementById('agg-owned').textContent = totalOwned;
                 document.getElementById('agg-total').textContent = totalCards;
-                document.getElementById('agg-value').textContent = '$' + totalValue;
-                document.getElementById('agg-owned-value').textContent = '$' + totalOwnedValue + ' owned';
-                document.getElementById('agg-needed-value').textContent = '$' + totalNeededValue + ' needed';
+                document.getElementById('agg-value').textContent = '$' + totalOwnedValue;
+                document.getElementById('agg-needed-value').textContent = '$' + totalNeededValue + ' to complete';
             }
         }
 
@@ -536,7 +531,7 @@
                                     ${stats.owned} of ${stats.total} cards
                                 </div>
                                 <div class="value-line">
-                                    <span class="value-owned">$${stats.ownedValue || 0} owned</span> ·
+                                    <span class="value-owned">$${stats.ownedValue || 0} value</span> ·
                                     <span class="value-needed">$${stats.neededValue || 0} to complete</span>
                                 </div>
                             </div>


### PR DESCRIPTION
## Summary
Fixes four issues in one PR since they're all small, independent changes:

**#555 - Card rendering style no longer depends on data field presence**
- Removed `if (card.years)` branching at checklist-engine.js:699 that caused cards with/without `years` to render differently
- All cards now use the standard layout (card-title, card-number, card-type)

**#557 - Estimated value reflects owned cards only**
- "Est. Value" now shows the sum of owned card prices (was showing total of all cards)
- Breakdown changed from "$X owned / $X needed" to just "$X to complete"
- Updated on both checklist pages and index page aggregate stats

**#556 - Pasting image URL no longer opens image editor**
- When saving a card with an eBay/Beckett URL, the image is now auto-processed (fetched, resized, uploaded to R2) without opening the crop/edit modal
- The explicit "Process" button still opens the editor for manual cropping

**#560 - External gist updates preserved on save**
- Before saving, the engine now re-fetches the latest card data from the gist and merges
- Local edits overlay fresh data, so externally-added fields (e.g. gradYear) are preserved
- Non-fatal: if the merge fetch fails, save proceeds with local data

## Test plan
- [ ] DC QBs: verify all cards render with same layout (no more compact vs standard difference)
- [ ] Any checklist: Est. Value shows owned total, not all-cards total
- [ ] Any checklist: breakdown says "$X to complete" instead of "$X owned / $X needed"
- [ ] Index page: aggregate Est. Value = sum of owned values across checklists
- [ ] Paste an eBay image URL, hit Save - should process without showing the editor
- [ ] Click the Process button on an eBay URL - editor should still open for cropping
- [ ] Add a field externally (via API), then edit a card in browser - external field preserved after save