### PR TITLE
Remove dead code from recent refactors

### DIFF
--- a/shared.css
+++ b/shared.css
@@ -561,16 +561,6 @@ h1 {
     white-space: nowrap;
 }
 
-.read-only-notice {
-    font-family: 'Barlow', sans-serif;
-    background: rgba(255, 182, 18, 0.2);
-    color: #FFB612;
-    padding: 8px 12px;
-    border-radius: var(--radius-md);
-    font-size: 0.85em;
-    font-weight: 500;
-    margin-right: auto;
-}
 
 /* ============================================
    Stats Section (Scoreboard Style)
@@ -631,7 +621,6 @@ h1 {
     margin-top: 6px;
 }
 
-.stat-breakdown .owned-value { color: var(--color-success); }
 .stat-breakdown .needed-value { color: var(--color-warning); }
 
 /* ============================================
@@ -1251,7 +1240,6 @@ select, input[type="text"] {
 @media print {
     .card { break-inside: avoid; }
     .search-link { display: none; }
-    .auth-bar { display: none; }
     .filters { display: none; }
     .clear-btn { display: none; }
     body { background: white; }
@@ -3217,14 +3205,6 @@ select, input[type="text"] {
 .player-record {
     font-size: 0.7em;
     color: #aaa;
-}
-.card-info {
-    font-size: 0.75em;
-    color: #bbb;
-    margin: 6px 0;
-}
-.card-set {
-    color: var(--color-accent-text, var(--color-accent, #f39c12));
 }
 
 /* Intro text block (used by dynamic checklists) */

--- a/shared.js
+++ b/shared.js
@@ -512,20 +512,6 @@ class ChecklistManager {
         const clearBtn = document.querySelector('.clear-btn');
         if (clearBtn) clearBtn.style.display = this.isReadOnly ? 'none' : '';
 
-        // Show read-only notice
-        const authBar = document.getElementById('auth-bar');
-        const existingNotice = document.querySelector('.read-only-notice');
-        if (this.isReadOnly && !existingNotice && authBar) {
-            const notice = document.createElement('span');
-            notice.className = 'read-only-notice';
-            notice.textContent = `Viewing ${this.ownerUsername}'s collection`;
-            const rightSection = authBar.querySelector('.right-section');
-            if (rightSection) {
-                authBar.insertBefore(notice, rightSection);
-            }
-        } else if (!this.isReadOnly && existingNotice) {
-            existingNotice.remove();
-        }
     }
 
     // Clear all owned cards (with confirmation)
@@ -1994,8 +1980,6 @@ class CardEditorModal {
         // Types: 'text', 'select', 'checkbox'
         // For select: options is array of { value, label } or just strings
         this.customFields = options.customFields || {};
-        // priceInAttributes is now always true - price renders in the compact attributes row
-        this.priceInAttributes = true;
     }
 
     // Generate eBay search term from card data


### PR DESCRIPTION
## Summary
Pure deletion - removes 36 lines of dead code left behind by recent changes.

- `.card-info` / `.card-set` CSS - orphaned when `card.years` branching was removed in #561
- `.stat-breakdown .owned-value` CSS - element removed in #561
- `.auth-bar` print CSS + read-only notice JS - no `id="auth-bar"` element exists in any HTML
- `.read-only-notice` CSS - only created by the dead auth-bar JS above
- `priceInAttributes` flag - set to `true` but never read anywhere

## Test plan
- [ ] No visual regressions on any checklist page
- [ ] No console errors