### PR TITLE
Add Remove button for card images (#552)

### DIFF
--- a/shared.css
+++ b/shared.css
@@ -1937,14 +1937,20 @@ select, input[type="text"] {
     to { transform: rotate(360deg); }
 }
 
-/* Edit button - below preview, full width */
+/* Image actions row - below preview */
+.card-editor-image-actions {
+    display: none;
+    gap: 8px;
+    margin-top: 8px;
+}
+
+/* Edit button */
 .card-editor-edit-btn {
     display: none;
+    flex: 1;
     align-items: center;
     justify-content: center;
-    width: 100%;
     padding: 8px 16px;
-    margin-top: 8px;
     background: linear-gradient(135deg, #43e97b 0%, #38f9d7 100%);
     border: none;
     border-radius: 4px;
@@ -1956,6 +1962,31 @@ select, input[type="text"] {
     cursor: pointer;
     transition: all 0.2s;
     white-space: nowrap;
+}
+
+/* Remove button */
+.card-editor-remove-btn {
+    flex: 1;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding: 8px 16px;
+    background: linear-gradient(135deg, #e94343 0%, #f95c38 100%);
+    border: none;
+    border-radius: 4px;
+    color: #fff;
+    font-family: 'Barlow', sans-serif;
+    font-size: 12px;
+    font-weight: 600;
+    letter-spacing: 0.04em;
+    cursor: pointer;
+    transition: all 0.2s;
+    white-space: nowrap;
+}
+
+.card-editor-remove-btn:hover {
+    transform: translateY(-1px);
+    box-shadow: 0 4px 12px rgba(233, 67, 67, 0.4);
 }
 
 .card-editor-edit-btn:hover {

--- a/shared.js
+++ b/shared.js
@@ -2258,10 +2258,13 @@ class CardEditorModal {
                             <div class="card-editor-image-preview" id="editor-img-dropzone">
                                 <span class="placeholder">No image</span>
                             </div>
-                            <button type="button" class="card-editor-edit-btn" id="editor-edit-img" title="Edit existing image" style="display: none;">
-                                <span class="edit-text">Edit</span>
-                                <span class="edit-spinner"></span>
-                            </button>
+                            <div class="card-editor-image-actions" id="editor-image-actions" style="display: none;">
+                                <button type="button" class="card-editor-edit-btn" id="editor-edit-img" title="Edit existing image">
+                                    <span class="edit-text">Edit</span>
+                                    <span class="edit-spinner"></span>
+                                </button>
+                                <button type="button" class="card-editor-remove-btn" id="editor-remove-img" title="Remove image">Remove</button>
+                            </div>
                         </div>
                     </div>
                 </div>
@@ -2364,7 +2367,7 @@ class CardEditorModal {
         this.backdrop.querySelector('#editor-img').oninput = (e) => {
             this.updateImagePreview(e.target.value);
             this.updateProcessButton(e.target.value);
-            this.updateEditButton(e.target.value);
+            this.updateImageActions(e.target.value);
         };
 
         // Process image button
@@ -2372,6 +2375,9 @@ class CardEditorModal {
 
         // Edit existing image button
         this.backdrop.querySelector('#editor-edit-img').onclick = () => this.editExistingImage();
+
+        // Remove image button
+        this.backdrop.querySelector('#editor-remove-img').onclick = () => this.removeImage();
 
         // Upload zone click
         this.backdrop.querySelector('#editor-upload-zone').onclick = () => {
@@ -2467,13 +2473,30 @@ class CardEditorModal {
         btn.style.display = isEbay ? 'flex' : 'none';
     }
 
-    // Update edit button visibility based on URL (show for local or R2 images)
-    updateEditButton(url) {
-        const btn = this.backdrop.querySelector('#editor-edit-img');
-        if (!btn) return;
+    // Update image actions row visibility (show for any image, edit only for R2/local)
+    updateImageActions(url) {
+        const actionsRow = this.backdrop.querySelector('#editor-image-actions');
+        const editBtn = this.backdrop.querySelector('#editor-edit-img');
+        if (!actionsRow) return;
 
-        const isEditable = url && (url.startsWith(this.imageFolder) || url.startsWith(R2_IMAGE_BASE));
-        btn.style.display = isEditable ? 'flex' : 'none';
+        const hasImage = url && url.trim() !== '';
+        actionsRow.style.display = hasImage ? 'flex' : 'none';
+
+        if (editBtn) {
+            const isEditable = hasImage && (url.startsWith(this.imageFolder) || url.startsWith(R2_IMAGE_BASE));
+            editBtn.style.display = isEditable ? 'flex' : 'none';
+        }
+    }
+
+    // Remove image from card
+    removeImage() {
+        if (!confirm('Remove this image?')) return;
+
+        const imgInput = this.backdrop.querySelector('#editor-img');
+        imgInput.value = '';
+        this.updateImagePreview('');
+        this.updateImageActions('');
+        this.setDirty(true);
     }
 
     // Reset image tabs to "Paste URL"
@@ -2546,7 +2569,7 @@ class CardEditorModal {
             imgInput.value = r2Url;
             this.updateImagePreview(`data:image/webp;base64,${base64Data}`);
             this.updateProcessButton(r2Url);
-            this.updateEditButton(r2Url);
+            this.updateImageActions(r2Url);
             this.setDirty(true);
 
             btn.title = 'Done! Image uploaded';
@@ -2630,7 +2653,7 @@ class CardEditorModal {
             imgInput.value = r2Url;
             this.updateImagePreview(`data:image/webp;base64,${base64Content}`);
             this.updateProcessButton(r2Url);
-            this.updateEditButton(r2Url);
+            this.updateImageActions(r2Url);
             this.setDirty(true);
 
             btn.title = 'Done! Image uploaded';
@@ -2712,7 +2735,7 @@ class CardEditorModal {
             imgInput.value = r2Url;
             this.updateImagePreview(`data:image/webp;base64,${base64Content}`);
             this.updateProcessButton(r2Url);
-            this.updateEditButton(r2Url);
+            this.updateImageActions(r2Url);
             this.setDirty(true);
 
             // Clear file input for future uploads
@@ -2784,7 +2807,7 @@ class CardEditorModal {
 
         this.updateImagePreview(cardData.img);
         this.updateProcessButton(cardData.img);
-        this.updateEditButton(cardData.img);
+        this.updateImageActions(cardData.img);
         this.setDirty(false);
         this.ebayManuallyEdited = false;
 
@@ -2838,7 +2861,7 @@ class CardEditorModal {
         }
         this.updateImagePreview('');
         this.updateProcessButton('');
-        this.updateEditButton('');
+        this.updateImageActions('');
         this.setDirty(false);
         this.ebayManuallyEdited = false;
 


### PR DESCRIPTION
## Summary
- Adds a Remove button next to the existing Edit button below the image preview in the card editor
- Remove clears the image URL from card data; the R2 file is left as-is (orphan cleanup tracked in #479)
- Renamed `updateEditButton()` to `updateImageActions()` - actions row shows for any image, Edit button only for R2/local images

## Test plan
- [ ] Card with image: Edit + Remove buttons visible below preview
- [ ] Click Remove, confirm -> image clears, buttons hide, dirty state set
- [ ] Save -> card no longer has `img` field in gist
- [ ] Card without image: no buttons shown
- [ ] Upload/paste image -> buttons appear
- [ ] Edit button only shows for R2/local images; Remove shows for any image URL
- [ ] `npm test` passes

Closes #552