### PR TITLE
Fix rotation crop box misalignment (#559)

### DIFF
--- a/shared.js
+++ b/shared.js
@@ -1412,6 +1412,7 @@ class ImageEditorModal {
                 // Apply total rotation (base + fine)
                 if (this.cropper) {
                     this.cropper.rotateTo(this.baseRotation + this.fineRotation);
+                    this.cropper.setCropBoxData(this.cropper.getCanvasData());
                 }
             };
             // Store for use in handleToolAction


### PR DESCRIPTION
## Summary
- After rotating a card image, the crop box now snaps to match the rotated canvas dimensions
- Adds `setCropBoxData(getCanvasData())` after `rotateTo()` in `setFineRotation()`, which is the single codepath for all rotation changes (slider, input, 90-degree buttons)

Closes #559

## Test plan
- [ ] Open image editor on a landscape image, rotate 90 degrees - crop box snaps to fit the rotated image
- [ ] Fine-rotate with slider - crop box stays aligned
- [ ] Reset button still works as expected
- [ ] Verify on a portrait image as well