### PR TITLE
Fix price field stretching full width in editor

### DIFF
--- a/shared.js
+++ b/shared.js
@@ -2019,6 +2019,14 @@ class CardEditorModal {
             // fullWidth fields (e.g. variant) are rendered inline in the template grid, not here
             const rowFields = fields.filter(([_, c]) => !c.fullWidth);
 
+            // If no custom attribute fields, render price as a compact grid field
+            if (rowFields.length === 0) {
+                return `<div class="card-editor-field">
+                    <label class="card-editor-label">Price</label>
+                    <input type="text" class="card-editor-input" id="editor-price" placeholder="$" inputmode="numeric">
+                </div>`;
+            }
+
             const innerHtml = rowFields.map(([fieldName, config]) => {
                 const id = `editor-${fieldName}`;
                 if (config.type === 'checkbox') {


### PR DESCRIPTION
## Summary
- When a checklist has no custom attribute fields (auto, patch, serial), the price field was the only item in the flex attributes row and stretched to fill the entire width
- Now renders price as a compact grid field instead when it's alone, matching the width of other fields like Set Name

## Test plan
- [ ] Open DC Legends checklist, edit a card - price field should be compact, not full width
- [ ] Open Jayden Daniels checklist, edit a card - attributes row (auto, patch, serial, price) should be unchanged