### PR TITLE
Refit canvas to container after rotation (#559)

### DIFF
--- a/shared.js
+++ b/shared.js
@@ -1690,7 +1690,10 @@ class ImageEditorModal {
                 const resultCanvas = PerspectiveTransform.transform(this.perspectiveCanvas, srcCorners);
                 imageSrc = resultCanvas ? resultCanvas.toDataURL('image/png') : this.cacheBustedSrc;
             } else {
-                imageSrc = this.cacheBustedSrc;
+                // Use perspective canvas as-is (preserves any previous crop)
+                imageSrc = this.perspectiveCanvas
+                    ? this.perspectiveCanvas.toDataURL('image/png')
+                    : this.cacheBustedSrc;
             }
 
             // Clean up perspective DOM


### PR DESCRIPTION
## Summary
- After rotation, refit the canvas to the container so the image doesn't overflow (especially landscape images rotated 90 degrees)
- Clear the crop box before refitting to bypass Cropper.js viewMode 1 constraint that prevents canvas shrinking
- Preserve crop box proportions during rotation (fine-rotate no longer resets a custom crop)
- Apply crop to perspective canvas when switching tabs (Crop -> Perspective shows the cropped image)
- Use perspective canvas content when switching back to Crop tab (preserves the crop)

Closes #559

## Test plan
- [ ] Open image editor on a landscape card, rotate 90 degrees - image fits in container, centered
- [ ] Fine-rotate with slider - crop box stays proportional
- [ ] Set a custom crop, then fine-rotate - crop is preserved
- [ ] Set a custom crop, switch to Perspective - perspective shows the cropped image
- [ ] Switch back to Crop from Perspective - crop is preserved
- [ ] Adjust perspective corners, switch to Crop - shows perspective-corrected image
- [ ] Reset button still works
- [ ] Done button saves correctly after crop + rotation