### PR TITLE
Move card number inline next to set name (#574)

### DIFF
--- a/checklist-engine.js
+++ b/checklist-engine.js
@@ -739,8 +739,12 @@ class ChecklistEngine {
         }
 
         // Card info (set, number, variant)
-        if (card.set) html += `<div class="card-title">${sanitizeText(card.set)}</div>`;
-        if (card.num || displayVariant) html += `<div class="card-number">${sanitizeText(card.num)} ${sanitizeText(displayVariant)}</div>`;
+        if (card.set) {
+            let titleHtml = sanitizeText(card.set);
+            if (card.num) titleHtml += ` <span class="card-number">${sanitizeText(card.num)}</span>`;
+            html += `<div class="card-title">${titleHtml}</div>`;
+        }
+        if (displayVariant) html += `<div class="card-variant">${sanitizeText(displayVariant)}</div>`;
         if (displayType) {
             html += `<div class="card-type">${sanitizeText(displayType)}</div>`;
         }

--- a/shared.css
+++ b/shared.css
@@ -939,6 +939,11 @@ select, input[type="text"] {
 }
 
 .card-number {
+    font-weight: 400;
+    color: var(--color-text-muted);
+}
+
+.card-variant {
     font-family: 'Barlow', sans-serif;
     font-size: 12px;
     font-weight: 500;


### PR DESCRIPTION
## Summary
- Card number now displays inline after the set name (e.g., "2024 Topps Chrome #150") instead of on a separate line
- Number is de-emphasized with lighter font weight and muted color
- Variant stays on its own line with new `.card-variant` class

## Test plan
- [ ] Cards with set + number show number inline after set name
- [ ] Cards with set only show just the set name
- [ ] Cards with variant show variant on its own line below
- [ ] Number has lighter weight than set name
- [ ] All checklist pages render correctly