### PR TITLE
Add hidden flag support for checklists (#577)

### DIFF
--- a/index.html
+++ b/index.html
@@ -482,7 +482,7 @@
             if (!registry || !registry.checklists) return {};
 
             const dynamicEntries = registry.checklists
-                .filter(e => e.type === 'dynamic')
+                .filter(e => e.type === 'dynamic' && !e.hidden)
                 .sort((a, b) => (a.title || a.navLabel).localeCompare(b.title || b.navLabel));
             if (dynamicEntries.length === 0) return {};
 

--- a/shared.js
+++ b/shared.js
@@ -3231,7 +3231,7 @@ const DynamicNav = {
         if (!navLinks) return;
 
         const dynamicEntries = registry.checklists
-            .filter(e => e.type === 'dynamic')
+            .filter(e => e.type === 'dynamic' && !e.hidden)
             .sort((a, b) => (a.navLabel || a.title).localeCompare(b.navLabel || b.title));
 
         // Remove any previously added dynamic links


### PR DESCRIPTION
## Summary
- Adds `hidden` flag support to checklist registry entries
- Entries with `hidden: true` are filtered out of the index page (`renderDynamicChecklists()`) and nav bar (`DynamicNav.renderNav()`)
- Hidden checklists remain accessible via direct URL (`?id=eagles-legends`)

## Test plan
- [ ] Confirm Eagles Legends loads at `?id=eagles-legends`
- [ ] Confirm it does NOT appear on index page or in nav
- [ ] Confirm card editor works for adding/editing cards
- [ ] Confirm other checklists are unaffected