### PR TITLE
Fix undefined in search URLs for cards without set/num

### DIFF
--- a/checklist-engine.js
+++ b/checklist-engine.js
@@ -695,7 +695,7 @@ class ChecklistEngine {
         const price = this.getPrice(card);
         const showPlayer = this.config.cardDisplay?.showPlayerName !== false && card.player;
         const playerForSearch = card.player ? card.player + ' ' : '';
-        const defaultSearch = encodeURIComponent(`${playerForSearch}${card.set} ${card.num}`);
+        const defaultSearch = encodeURIComponent(`${playerForSearch}${card.set || ''} ${card.num || ''}`.trim());
         const searchUrl = CardRenderer.getEbayUrl(card.search || defaultSearch);
         const priceSearchTerm = card.priceSearch || defaultSearch;
         const scpUrl = CardRenderer.getScpUrl(priceSearchTerm);


### PR DESCRIPTION
## Summary
- When a card has no `set` or `num` (e.g. player-only entries in Eagles Legends), the default eBay/SCP search term included "undefined"
- Now defaults missing properties to empty string and trims whitespace so the search is just the player name

## Test plan
- [ ] Open Eagles Legends checklist, click search icon on a card with no set/num
- [ ] Confirm eBay search is just the player name, no "undefined"