### PR TITLE
Show card position inline with player name (#577)

### DIFF
--- a/checklist-engine.js
+++ b/checklist-engine.js
@@ -498,6 +498,7 @@ class ChecklistEngine {
                 border-color: ${accent};
             }
             .player-name { color: ${linkColor}; font-size: 14px; font-weight: bold; margin-bottom: 4px; }
+            .player-position { font-weight: normal; opacity: 0.6; font-size: 12px; }
             .group-header {
                 border-bottom-color: ${accent};
             }
@@ -719,9 +720,10 @@ class ChecklistEngine {
         html += CardRenderer.renderCardImage(card.img, card.set, searchUrl);
         html += `</div>`;
 
-        // Player name (JMU, Washington QBs)
+        // Player name (JMU, Washington QBs) with optional position
         if (showPlayer) {
-            html += `<div class="player-name">${sanitizeText(card.player)}</div>`;
+            const posHtml = card.position ? ` <span class="player-position">${sanitizeText(card.position)}</span>` : '';
+            html += `<div class="player-name">${sanitizeText(card.player)}${posHtml}</div>`;
         }
 
         // Custom subtitle lines (config-driven)


### PR DESCRIPTION
## Summary
- Renders `card.position` (e.g. QB, DE, HC) inline next to the player name with subtle styling
- Position is editable via custom field config (`position: "after-num"`) without rendering as a separate subtitle line
- Gist data updated: position separated from years so `field:years` sort works correctly

## Test plan
- [ ] Eagles Legends: positions show next to player names (e.g. "Chuck Bednarik C/LB")
- [ ] Eagles Legends: sort by years works correctly (numeric sort, not "QB, 1999...")
- [ ] Washington DC Legends: unaffected (position data exists but was already not displayed)
- [ ] Card editor: position field is editable for Eagles checklist