### PR TITLE
Renderer adds # prefix to card numbers instead of storing in data

### DIFF
--- a/checklist-engine.js
+++ b/checklist-engine.js
@@ -748,7 +748,10 @@ class ChecklistEngine {
         // Card info (set, number, variant)
         if (card.set) {
             let titleHtml = sanitizeText(card.set);
-            if (card.num) titleHtml += ` <span class="card-number">${sanitizeText(card.num)}</span>`;
+            if (card.num) {
+                const num = card.num.startsWith('#') ? card.num : '#' + card.num;
+                titleHtml += ` <span class="card-number">${sanitizeText(num)}</span>`;
+            }
             html += `<div class="card-title">${titleHtml}</div>`;
         }
         if (displayVariant) html += `<div class="card-variant">${sanitizeText(displayVariant)}</div>`;

--- a/shared.js
+++ b/shared.js
@@ -2938,11 +2938,8 @@ class CardEditorModal {
 
     // Gather form data
     getFormData() {
-        // Add # prefix to card number if not present
-        let num = this.backdrop.querySelector('#editor-num').value.trim();
-        if (num && !num.startsWith('#')) {
-            num = '#' + num;
-        }
+        // Strip # prefix from card number (renderer adds it for display)
+        let num = this.backdrop.querySelector('#editor-num').value.trim().replace(/^#/, '');
 
         // Core fields (normalize smart quotes from mobile keyboards)
         const data = {
@@ -3055,7 +3052,7 @@ class CardEditorModal {
         // Check if set or num changed and eBay search wasn't manually edited
         if (!this.ebayManuallyEdited && this.currentCard) {
             const setChanged = data.set !== (this.currentCard.set || '');
-            const numChanged = data.num !== (this.currentCard.num || '');
+            const numChanged = data.num !== (this.currentCard.num || '').replace(/^#/, '');
 
             if (setChanged || numChanged) {
                 // Regenerate search term


### PR DESCRIPTION
Closes #586

## Summary
- Renderer adds `#` prefix when displaying card numbers, instead of storing it in the data
- Editor save now strips `#` from num field so new saves store clean numbers (e.g., `123` instead of `#123`)
- Backward compatible: handles both old data with `#` and new data without
- Card IDs unchanged - no ownership data affected

## Test plan
- [ ] Existing cards with `#` in data still display correctly (e.g., `#123`)
- [ ] Editing and saving a card stores num without `#` prefix
- [ ] Card number displays with `#` after re-save
- [ ] Owned status preserved after card re-save
- [ ] eBay search URLs still correct (no `#` in search)