### PR TITLE
Fix editor layout: position next to player name, compact attributes

### DIFF
--- a/checklist-engine.js
+++ b/checklist-engine.js
@@ -1369,6 +1369,15 @@ class ChecklistEngine {
         const categories = this.config.categories || [];
         const customFields = this.config.customFields || {};
 
+        // Normalize: position field should be next to player name (top), not after-num
+        if (customFields.position?.position === 'after-num') {
+            customFields.position = { ...customFields.position, position: undefined };
+        }
+        // When position field exists alongside player, player shouldn't be full-width
+        if (customFields.position && customFields.player?.fullWidth) {
+            customFields.player = { ...customFields.player, fullWidth: false };
+        }
+
         // Build categories list for dropdown (with optgroup for subcategories)
         let editorCategories;
         if (this._isFlat()) {

--- a/shared.css
+++ b/shared.css
@@ -1746,8 +1746,6 @@ select, input[type="text"] {
     display: flex;
     align-items: center;
     gap: 6px;
-    flex: 1;
-    min-width: 0;
 }
 
 .card-editor-attr-text label {
@@ -1759,9 +1757,7 @@ select, input[type="text"] {
 }
 
 .card-editor-attr-text .card-editor-input {
-    flex: 1;
-    min-width: 50px;
-    width: auto;
+    width: 60px;
     padding: 8px 10px !important;
     font-size: 13px !important;
 }

--- a/shared.js
+++ b/shared.js
@@ -4215,15 +4215,15 @@ class ChecklistCreatorModal {
 
         // Player field (if showing player names)
         if (config.cardDisplay.showPlayerName) {
-            customFields.player = { label: 'Player Name', type: 'text', fullWidth: true };
+            customFields.player = { label: 'Player Name', type: 'text', fullWidth: !showPosition };
             config.cardDisplay.includePlayerInCardId = true;
         } else {
             delete config.cardDisplay.includePlayerInCardId;
         }
 
-        // Position field (if showing position)
+        // Position field (next to player name)
         if (showPosition) {
-            customFields.position = { label: 'Position', type: 'text', position: 'after-num' };
+            customFields.position = { label: 'Position', type: 'text' };
         }
 
         // Subtitle lines


### PR DESCRIPTION
## Summary
- Player Name and Position fields now share a row (3fr + 1fr) instead of Position being on its own row
- Attributes row (Patch, Run, etc.) no longer stretches to fill the full width - items stay compact
- Runtime normalization in checklist-engine handles existing gist configs that had `after-num` positioning
- Updated eagles-legends and washington-all-pros gist configs to remove `after-num` and `fullWidth`

## Test plan
- [ ] Open editor on a checklist with position enabled (e.g. washington-all-pros) - Position should be next to Player Name
- [ ] Open editor on a checklist with only Patch + Run attributes - Run input should be compact, not stretched
- [ ] Open editor on a checklist without position (e.g. jayden-daniels) - Player Name should still be full width
- [ ] Verify dark theme works correctly