### PR TITLE
Fix attribute Run input stretching full width

### DIFF
--- a/shared.css
+++ b/shared.css
@@ -1756,7 +1756,7 @@ select, input[type="text"] {
     white-space: nowrap;
 }
 
-.card-editor-attr-text .card-editor-input {
+.card-editor-modal .card-editor-attr-text .card-editor-input {
     width: 60px;
     padding: 8px 10px !important;
     font-size: 13px !important;


### PR DESCRIPTION
## Summary
- The `.card-editor-attr-text .card-editor-input` selector had lower specificity than the base `.card-editor-modal .card-editor-input` rule, so `width: 60px` was being ignored
- Added `.card-editor-modal` prefix to match specificity

## Test plan
- [ ] Open editor on a checklist with Patch + Run attributes - Run input should be ~60px wide, not stretched