### PR TITLE
Fix image upload error surfacing and empty filename edge case

### DIFF
--- a/github-sync.js
+++ b/github-sync.js
@@ -614,7 +614,7 @@ class GitHubSync {
 
         if (!response.ok) {
             const body = await response.json().catch(() => ({}));
-            if (response.status === 403 && body.error) {
+            if (body.error) {
                 throw new Error(body.error);
             }
             throw new Error(`Upload failed (${response.status})`);

--- a/shared.js
+++ b/shared.js
@@ -1124,7 +1124,8 @@ class ImageProcessor {
 
         // Create filename, sanitize for filesystem
         const name = parts.join('_').replace(/[^a-z0-9_-]/g, '');
-        return `${name}.webp`;
+        // Fall back to timestamp if all card fields are empty
+        return `${name || Date.now().toString(36)}.webp`;
     }
 
     // Full pipeline: fetch, process, return base64 content (for committing)
@@ -2670,7 +2671,6 @@ class CardEditorModal {
             // Get card data from form to generate filename
             const cardData = {
                 set: this.backdrop.querySelector('#editor-set')?.value || '',
-                name: this.backdrop.querySelector('#editor-name')?.value || '',
                 num: this.backdrop.querySelector('#editor-num')?.value || ''
             };
 
@@ -2753,7 +2753,6 @@ class CardEditorModal {
             // Get card data from form to generate filename
             const cardData = {
                 set: this.backdrop.querySelector('#editor-set')?.value || '',
-                name: this.backdrop.querySelector('#editor-name')?.value || '',
                 num: this.backdrop.querySelector('#editor-num')?.value || ''
             };
 


### PR DESCRIPTION
## Summary
- Surface the Worker's actual error message for all upload failure status codes, not just 403. Would have shown "Invalid base64 data" instead of "Upload failed (400)"
- Remove dead `#editor-name` DOM queries (element never exists in the editor template)
- Fall back to timestamp-based filename when all card data fields are empty, preventing `.webp`-only filenames that fail Worker validation

## Test plan
- [ ] Upload an image to a card - verify it works
- [ ] Check browser console for descriptive error messages on upload failures