### PR TITLE
Encode double quotes in eBay search URLs

### DIFF
--- a/shared.js
+++ b/shared.js
@@ -616,7 +616,7 @@ const CardRenderer = {
 
     // Generate eBay search URL
     getEbayUrl(searchTerm) {
-        return `https://www.ebay.com/sch/i.html?_nkw=${searchTerm}&_sop=15&LH_BIN=1`;
+        return `https://www.ebay.com/sch/i.html?_nkw=${searchTerm.replace(/"/g, '%22')}&_sop=15&LH_BIN=1`;
     },
 
     // Generate SportsCardsPro search URL


### PR DESCRIPTION
## Summary
- Search terms with quoted phrases (e.g. `lamar+"bubba"+tyer`) had literal `"` in the URL that broke the `onerror` attribute in `renderCardImage`, causing the "No image" fallback HTML to render as broken text
- Encodes `"` as `%22` in `getEbayUrl` - eBay handles this identically

## Test plan
- [ ] Verify Bubba Tyer card no longer shows `No image"">` text
- [ ] Verify eBay search links still work for cards with quoted search terms