### PR TITLE
Add timestamp suffix to image filenames to prevent collisions

### DIFF
--- a/shared.js
+++ b/shared.js
@@ -2776,7 +2776,7 @@ class CardEditorModal {
             };
 
             // Generate filename and key
-            const filename = this.imageProcessor.generateFilename(cardData);
+            const filename = this.imageProcessor.generateFilename(cardData, true);
             const key = `${this.imageFolder}/${filename}`;
 
             // Resize and convert to WebP
@@ -2858,7 +2858,7 @@ class CardEditorModal {
             };
 
             // Generate filename and key
-            const filename = this.imageProcessor.generateFilename(cardData);
+            const filename = this.imageProcessor.generateFilename(cardData, true);
             const key = `${this.imageFolder}/${filename}`;
 
             // Process the image (resize, convert to webp)


### PR DESCRIPTION
## Summary
- Cards with the same set and number but different variants (e.g. 2024 Score Halloween #26 Green vs Orange) generated identical filenames, causing the second upload to overwrite the first in R2
- Pass `addTimestamp=true` to `generateFilename` so every image gets a unique suffix (e.g. `2024_score_halloween_26_m5k2j3w.webp`)

## Test plan
- [ ] Upload images for two cards with same set/number but different variants
- [ ] Verify both images are distinct after upload