### PR TITLE
Add custom domain cards.iammike.org

### DIFF
--- a/CNAME
+++ b/CNAME
@@ -1,0 +1,1 @@
+cards.iammike.org

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 A modern web app for tracking sports card collections with cloud sync, real-time stats, and inline editing.
 
-**Live site: [iammike.github.io/sports-card-checklists](https://iammike.github.io/sports-card-checklists/)**
+**Live site: [cards.iammike.org](https://cards.iammike.org/)**
 
 ![JavaScript](https://img.shields.io/badge/JavaScript-Vanilla-yellow) ![GitHub Pages](https://img.shields.io/badge/Hosted-GitHub%20Pages-blue) ![Cloudflare](https://img.shields.io/badge/Auth-Cloudflare%20Workers-orange)
 

--- a/worker.js
+++ b/worker.js
@@ -8,6 +8,7 @@
 // 4. Deploy and note your worker URL (e.g., https://your-worker.your-subdomain.workers.dev)
 
 const ALLOWED_ORIGINS = [
+  'https://cards.iammike.org',
   'https://iammike.github.io',
   'http://localhost:8000',
   'http://127.0.0.1:8000',
@@ -55,6 +56,7 @@ async function handleServeImage(request, env, key) {
 // Preview sites share the same R2 bucket, so uploads from them
 // would overwrite production images.
 const UPLOAD_ALLOWED_ORIGINS = [
+  'https://cards.iammike.org',
   'https://iammike.github.io',
 ];
 


### PR DESCRIPTION
## Summary
- Add `CNAME` file for GitHub Pages custom domain (`cards.iammike.org`)
- Add `cards.iammike.org` to Worker's `ALLOWED_ORIGINS` and `UPLOAD_ALLOWED_ORIGINS`
- Update README live site link

## Setup steps (manual)
1. Add DNS CNAME record at hosting.com: `cards` -> `iammike.github.io`
2. Merge this PR (deploys CNAME file and updated Worker)
3. In GitHub repo Settings > Pages, set custom domain to `cards.iammike.org`
4. Wait for DNS propagation and GitHub's SSL certificate provisioning
5. Add `https://cards.iammike.org/` as a callback URL in the GitHub OAuth app settings