### PR TITLE
Fix scroll-to-card after save

### DIFF
--- a/checklist-engine.js
+++ b/checklist-engine.js
@@ -1438,11 +1438,14 @@ class ChecklistEngine {
                 }
                 this.renderCards();
                 this.updateStats();
-                // Scroll to the card
-                const cardEl = document.querySelector(`.card[data-id="${newId}"]`);
-                if (cardEl) {
-                    cardEl.scrollIntoView({ behavior: 'smooth', block: 'center' });
-                    if (isNew) cardEl.classList.add('card-highlight');
+                // Scroll to the card (find by matching card ID in rendered cards)
+                const cardIdx = this._renderedCards.findIndex(c => c && this.getCardId(c) === newId);
+                if (cardIdx !== -1) {
+                    const cardEl = document.querySelector(`.card[data-card-idx="${cardIdx}"]`);
+                    if (cardEl) {
+                        cardEl.scrollIntoView({ behavior: 'smooth', block: 'center' });
+                        if (isNew) cardEl.classList.add('card-highlight');
+                    }
                 }
                 this.checklistManager.setSyncStatus('syncing', 'Saving...');
                 await this._saveCardData();


### PR DESCRIPTION
## Summary
- Cards are rendered with `data-card-idx` but the scroll code was querying `data-id` (which doesn't exist), so `scrollIntoView` never fired
- Now finds the card by matching its ID against `_renderedCards`, then scrolls to the element with the matching `data-card-idx`
- New cards also get a highlight pulse animation

## Test plan
- [ ] Edit a card and save - should scroll to the card
- [ ] Add a new card - should scroll to it with a highlight pulse
- [ ] Verify scroll works when the card is below the fold