### PR TITLE
Add completion signal to extra category pills

### DIFF
--- a/index.html
+++ b/index.html
@@ -222,6 +222,13 @@
             color: #888;
             transform: translateY(1px);
         }
+        .checklist-card .stat-pill.complete {
+            background: rgba(76, 175, 80, 0.12);
+            color: #4caf50;
+        }
+        .checklist-card .stat-pill.complete .count {
+            color: #4caf50;
+        }
         .coming-soon {
             opacity: 0.5;
             pointer-events: none;
@@ -542,7 +549,8 @@
                                 const total = stats[pill.id + 'Total'] || 0;
                                 if (total === 0) return '';
                                 const pillPct = Math.round((owned / total) * 100);
-                                return `<span class="stat-pill" style="--pill-pct: ${pillPct}%">${sanitizeText(pill.label)} <span class="count">${owned}/${total}</span></span>`;
+                                const isComplete = owned === total;
+                                return `<span class="stat-pill${isComplete ? ' complete' : ''}" style="--pill-pct: ${pillPct}%">${sanitizeText(pill.label)} <span class="count">${isComplete ? '\u2713' : `${owned}/${total}`}</span></span>`;
                             }).join('')}
                         </div>` : ''}
                         </div>


### PR DESCRIPTION
## Summary
- When all cards in an extra category are owned, the pill on the index page now shows a green tint with a checkmark instead of the numeric count
- Incomplete pills remain unchanged (showing `owned/total` count with the gradient fill)

## Test plan
- [ ] Open the index page while logged in
- [ ] Verify pills for incomplete categories still show `X/Y` count
- [ ] Complete all cards in an extra category and verify the pill turns green with a checkmark
- [ ] Verify the green styling looks good against different checklist accent colors

Closes #569