### PR TITLE
De-duplicate owned count in aggregate stats

### DIFF
--- a/index.html
+++ b/index.html
@@ -488,8 +488,9 @@
                 const data = isLoggedIn ? await githubSync.loadData() : await githubSync.loadPublicData();
                 const allOwned = data?.checklists || {};
 
+                // Variant excluded - same player+set+num is the same physical card
                 const fingerprint = (card) => {
-                    const str = (card.player || '') + (card.set || '') + (card.num || '') + (card.variant || '');
+                    const str = (card.player || '') + (card.set || '') + (card.num || '');
                     return btoa(str.replace(/[^\x00-\xFF]/g, '_')).replace(/[^a-zA-Z0-9]/g, '');
                 };
 


### PR DESCRIPTION
## Summary
- Cards appearing on multiple checklists (e.g., Jayden Daniels on both the JD checklist and Washington All-Pros) were counted multiple times in the index page "Cards Owned" aggregate
- Now unions all owned card IDs across visible checklists into a Set, using the unique count instead
- Individual checklist stats remain unchanged - only the aggregate rollup is de-duped
- Values (Est. Value, to complete) still use per-checklist sums since de-duping those would require loading all card data

## Test plan
- [ ] Open the index page while logged in
- [ ] Verify aggregate "Cards Owned" count is less than or equal to the sum of individual checklist owned counts
- [ ] If a card appears on multiple checklists, verify it's only counted once in the aggregate
- [ ] Verify individual checklist card counts on each checklist card are unchanged

Closes #532