### PR TITLE
Delete old R2 images when replacing card images

### DIFF
--- a/worker.js
+++ b/worker.js
@@ -304,11 +304,9 @@ async function handleListImages(request, env, corsOrigin) {
   }
 
   try {
-    const listed = await env.IMAGES_BUCKET.list({
-      prefix: 'images/',
-      cursor,
-      limit: 1000,
-    });
+    const listOptions = { prefix: 'images/', limit: 1000 };
+    if (cursor) listOptions.cursor = cursor;
+    const listed = await env.IMAGES_BUCKET.list(listOptions);
 
     const objects = listed.objects.map(obj => ({
       key: obj.key,


### PR DESCRIPTION
## Summary
- Add `DELETE /delete-image` and `POST /list-images` endpoints to the Cloudflare Worker
- Add `deleteImage()` and `listImages()` methods to GitHubSync
- When a card image is re-cropped or re-uploaded, delete the old R2 object after successful upload (fire-and-forget)
- Add `r2KeyFromUrl()` helper for consistent key extraction across all three upload paths
- Add browser console cleanup script for existing orphans (`scripts/cleanup-orphaned-images.js`, gitignored)

Closes #490

## Test plan
- [ ] Deploy worker, run cleanup script dry-run to verify it lists R2 objects and finds orphans
- [ ] Edit an existing card image (crop), verify old R2 object is deleted
- [ ] Upload a new image via Process Image over an existing one, verify old deleted
- [ ] Upload a new image via Upload File over an existing one, verify old deleted
- [ ] Run cleanup script with `DRY_RUN = false` to purge existing orphans