### PR TITLE
Add confirmation before dismissing image editor on backdrop click

### DIFF
--- a/image-editor.js
+++ b/image-editor.js
@@ -416,7 +416,10 @@ class ImageEditorModal {
 
         // Backdrop click to close
         this.backdrop.onclick = (e) => {
-            if (e.target === this.backdrop) this.cancel();
+            if (e.target === this.backdrop) {
+                if (!confirm('Discard image edits?')) return;
+                this.cancel();
+            }
         };
 
         // Cancel button


### PR DESCRIPTION
## Summary
- Adds a confirmation dialog ("Discard image edits?") when clicking outside the image editor modal
- Prevents accidental loss of in-progress image edits from stray clicks on the backdrop

## Test plan
- [ ] Open image editor, make edits, click on the backdrop - confirm dialog should appear
- [ ] Click "Cancel" on the confirm dialog - editor stays open with edits preserved
- [ ] Click "OK" on the confirm dialog - editor closes and edits are discarded
- [ ] Close button (X) and Cancel button still work without a confirm dialog
- [ ] Confirm/Apply button still saves edits normally

Closes #614