### PR TITLE
Add Enter key handler to image editor modal

### DIFF
--- a/image-editor.js
+++ b/image-editor.js
@@ -523,6 +523,16 @@ class ImageEditorModal {
                 this.cancel();
             }
         });
+
+        // Enter key to confirm
+        document.addEventListener('keydown', (e) => {
+            if (e.key === 'Enter' && this.backdrop.classList.contains('active')) {
+                // Don't trigger if focused on an input (like the rotation text field)
+                if (e.target.tagName === 'INPUT') return;
+                e.preventDefault();
+                this.confirm();
+            }
+        });
     }
 
     // Handle toolbar actions


### PR DESCRIPTION
## Summary
- Adds an Enter key listener to the image editor modal that triggers `confirm()` (Done), matching the card editor modal's behavior
- Skips the handler when an input field is focused (e.g., the rotation text field) to avoid interfering with text entry

Closes #617

## Test plan
- [ ] Open the image editor on any card
- [ ] Press Enter -- should confirm/save like clicking Done
- [ ] Focus the rotation input field and press Enter -- should NOT trigger confirm
- [ ] Press Escape -- should still cancel as before