### PR TITLE
Fix image editor UX and search term player name

### DIFF
--- a/checklist-engine.js
+++ b/checklist-engine.js
@@ -700,7 +700,8 @@ class ChecklistEngine {
         const owned = cardId ? this.isOwned(cardId) : false;
         const price = this.getPrice(card);
         const showPlayer = this.config.cardDisplay?.showPlayerName !== false && card.player;
-        const playerForSearch = card.player ? card.player + ' ' : '';
+        const playerForSearch = card.player ? card.player + ' ' :
+            (this.config.cardDisplay?.showPlayerName === false && this.config.title ? this.config.title + ' ' : '');
         const defaultSearch = encodeURIComponent(`${playerForSearch}${card.set || ''} ${card.num || ''}`.trim());
         const searchUrl = CardRenderer.getEbayUrl(card.search || defaultSearch);
         const priceSearchTerm = card.priceSearch || defaultSearch;
@@ -1412,6 +1413,7 @@ class ChecklistEngine {
             imageFolder: `images/${this.id}`,
             categories: editorCategories,
             cardTypes: [],
+            playerName: this.config.cardDisplay?.showPlayerName === false ? this.config.title : '',
             isOwned: (cardId) => this.checklistManager.isOwned(cardId),
             onOwnedChange: (cardData, nowOwned) => {
                 const id = this.getCardId(cardData);

--- a/image-editor.js
+++ b/image-editor.js
@@ -414,9 +414,12 @@ class ImageEditorModal {
         // Close button
         this.backdrop.querySelector('.image-editor-close').onclick = () => this.cancel();
 
-        // Backdrop click to close
+        // Backdrop click to close (with confirmation)
         this.backdrop.onclick = (e) => {
-            if (e.target === this.backdrop) this.cancel();
+            if (e.target === this.backdrop) {
+                if (!confirm('Discard image edits?')) return;
+                this.cancel();
+            }
         };
 
         // Cancel button
@@ -521,6 +524,15 @@ class ImageEditorModal {
         document.addEventListener('keydown', (e) => {
             if (e.key === 'Escape' && this.backdrop.classList.contains('active')) {
                 this.cancel();
+            }
+        });
+
+        // Enter key to confirm (unless focused on an input)
+        document.addEventListener('keydown', (e) => {
+            if (e.key === 'Enter' && this.backdrop.classList.contains('active')) {
+                if (e.target.tagName === 'INPUT') return;
+                e.preventDefault();
+                this.confirm();
             }
         });
     }


### PR DESCRIPTION
## Summary
- **#614**: Backdrop click on image editor now shows "Discard image edits?" confirm before dismissing
- **#617**: Enter key confirms (Done) in the image editor, unless focused on an input field
- **#615**: Single-player checklists (e.g. Jayden Daniels) now include the checklist title as player name in eBay/SCP search terms, both on the card links and in the card editor

Closes #614, closes #615, closes #617

## Test plan
- [x] `npm test` - all 63 tests pass
- [ ] Open image editor, click backdrop - should see confirm dialog
- [ ] Open image editor, press Enter - should confirm (Done)
- [ ] Open image editor, type in rotation field, press Enter - should NOT confirm (stays in field)
- [ ] Jayden Daniels checklist: card eBay/SCP links include "Jayden Daniels" in search
- [ ] Jayden Daniels checklist: card editor search term includes "Jayden Daniels"
- [ ] Multi-player checklist (e.g. Washington QBs): search terms still use per-card player name