### PR TITLE
Fix image removal not persisting and delete R2 file (#625)

### DIFF
--- a/card-editor.js
+++ b/card-editor.js
@@ -814,6 +814,14 @@ class CardEditorModal {
         if (!confirm('Remove this image?')) return;
 
         const imgInput = this.backdrop.querySelector('#editor-img');
+        const oldUrl = imgInput.value.trim();
+
+        // Delete old R2 image (fire-and-forget)
+        const oldKey = r2KeyFromUrl(oldUrl);
+        if (oldKey) {
+            githubSync.deleteImage(oldKey).catch(() => {});
+        }
+
         imgInput.value = '';
         this.updateImagePreview('');
         this.updateImageActions('');
@@ -1251,11 +1259,8 @@ class CardEditorModal {
             type: this.backdrop.querySelector('#editor-type')?.value || ''
         };
 
-        // Image - only include if set (so clearing can delete it)
-        const imgVal = this.backdrop.querySelector('#editor-img').value.trim();
-        if (imgVal) {
-            data.img = imgVal;
-        }
+        // Image - always include so merge with fresh gist data doesn't restore deleted images
+        data.img = this.backdrop.querySelector('#editor-img').value.trim();
 
         // Category - only include if field exists
         const categoryField = this.backdrop.querySelector('#editor-category');


### PR DESCRIPTION
## Summary
- `removeImage()` now deletes the R2 file via `githubSync.deleteImage()` so orphaned images don't accumulate in storage
- `getFormData()` always includes `img` (even as empty string) so the fresh gist merge in `_mergeCardArrays` (`{ ...freshCard, ...localCard }`) doesn't re-introduce the deleted image URL

## Root cause
When a user removed an image, `getFormData()` omitted the `img` key entirely. During save, `_mergeWithFreshGistData()` merges local changes with fresh gist data using spread: `{ ...freshCard, ...localCard }`. Since `localCard` had no `img` property (it was deleted, not set to empty), `freshCard.img` survived the merge - effectively restoring the image.

## Test plan
- [ ] Open a card with an image
- [ ] Click "Remove" on the image
- [ ] Save the card
- [ ] Reload the page - image should still be gone
- [ ] Check R2 storage - old image file should be deleted