### PR TITLE
Add footer with GitHub link to index page

### DIFF
--- a/index.html
+++ b/index.html
@@ -17,7 +17,7 @@
             font-family: 'Barlow', -apple-system, BlinkMacSystemFont, sans-serif;
             background: linear-gradient(135deg, #1a1a2e 0%, #16213e 100%);
             min-height: 100vh;
-            padding: 0 20px 40px;
+            padding: 0 20px 0;
             color: #fff;
             --color-surface: rgba(255,255,255,0.05);
             --color-text: #ccc;
@@ -408,6 +408,31 @@
         .aggregate-stat-breakdown .owned { color: #4caf50; }
         .aggregate-stat-breakdown .needed { color: #ff9800; }
 
+        .site-footer {
+            margin-top: 60px;
+            padding: 20px;
+            text-align: center;
+            border-top: 1px solid rgba(255,255,255,0.06);
+        }
+        .site-footer a {
+            font-family: 'Barlow', sans-serif;
+            font-size: 0.75em;
+            font-weight: 500;
+            color: #555;
+            text-decoration: none;
+            display: inline-flex;
+            align-items: center;
+            gap: 6px;
+            transition: color 0.2s;
+        }
+        .site-footer a:hover {
+            color: #888;
+        }
+        .site-footer svg {
+            width: 14px;
+            height: 14px;
+            fill: currentColor;
+        }
         @media (max-width: 500px) {
             .logo-card { display: none; }
             .aggregate-stats { padding: 20px 16px 16px; }
@@ -492,6 +517,13 @@
         </div>
         <div class="checklist-grid"></div>
     </div>
+
+    <footer class="site-footer">
+        <a href="https://github.com/iammike/sports-card-checklists" target="_blank" rel="noopener">
+            <svg viewBox="0 0 16 16"><path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.01 8.01 0 0016 8c0-4.42-3.58-8-8-8z"/></svg>
+            View on GitHub
+        </a>
+    </footer>
 
     <script src="dist/app.min.js"></script>
     <script>


### PR DESCRIPTION
## Summary
- Adds a minimal footer below the checklist grid with a GitHub icon and "View on GitHub" link
- Subtle styling that matches the dark theme (muted color, light border-top separator)

Closes #630

## Test plan
- [ ] Footer visible at bottom of index page
- [ ] GitHub link opens repo in new tab
- [ ] Footer looks good on mobile

Preview: https://feature-index-footer.sports-card-checklists.pages.dev