### PR TITLE
Fix Enter key not saving card editor after image editing

### DIFF
--- a/src/card-editor.js
+++ b/src/card-editor.js
@@ -753,9 +753,11 @@ class CardEditorModal {
             }
         });
 
-        // Enter key to save (unless in a select or textarea)
-        modal.addEventListener('keydown', (e) => {
-            if (e.key === 'Enter' && !['SELECT', 'TEXTAREA'].includes(e.target.tagName)) {
+        // Enter key to save (unless in a select, textarea, or image editor is open)
+        document.addEventListener('keydown', (e) => {
+            if (e.key === 'Enter' && this.backdrop.classList.contains('active')
+                && !document.querySelector('.image-editor-backdrop.active')
+                && !['SELECT', 'TEXTAREA'].includes(e.target.tagName)) {
                 e.preventDefault();
                 this.save();
             }


### PR DESCRIPTION
## Summary
- Enter key in the card editor now works regardless of where focus is, not just when a text input is focused
- Previously the keydown listener was on the modal element, so it only fired when focus was inside it. After editing an image, focus often landed outside the modal's focusable elements.
- Now listens on `document` with guards: card editor must be open, image editor must not be open, and target must not be a select/textarea.

## Test plan
- [ ] Open card editor, edit an image, close image editor, press Enter - should save
- [ ] Open card editor, type in a text field, press Enter - should save
- [ ] Open card editor, open image editor, press Enter - should NOT save (image editor handles it)
- [ ] Press Escape still closes the editor