### PR TITLE
Add browser-like headers to image proxy fetch

### DIFF
--- a/worker.js
+++ b/worker.js
@@ -350,8 +350,13 @@ async function handleProxyImage(request, corsOrigin) {
       });
     }
 
-    // Fetch the image
-    const imageResponse = await fetch(url);
+    // Fetch the image (with browser-like UA so hosts don't reject the request)
+    const imageResponse = await fetch(url, {
+      headers: {
+        'User-Agent': 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/131.0.0.0 Safari/537.36',
+        'Accept': 'image/webp,image/apng,image/*,*/*;q=0.8',
+      },
+    });
     if (!imageResponse.ok) {
       return new Response(JSON.stringify({ error: 'Failed to fetch image' }), {
         status: 502,


### PR DESCRIPTION
## Summary
- Beckett image URLs return non-200 responses when fetched without a browser-like User-Agent, causing the proxy to return 502
- Added User-Agent and Accept headers to the outbound fetch in the proxy-image handler

## Test plan
- [ ] Paste a Beckett image URL (e.g. `https://img.beckett.com/images/items_stock/185224/8841482/8841719/front.jpg`) into a card's image field
- [ ] Click process - verify it fetches and uploads successfully
- [ ] Verify eBay image URLs still work as before