### PR TITLE
Fix image editor save buttons not visible on mobile

### DIFF
--- a/shared.css
+++ b/shared.css
@@ -2624,6 +2624,7 @@ select, input[type="text"] {
     .image-editor-modal {
         width: 100%;
         height: 100vh;
+        height: 100dvh;
         max-width: none;
         max-height: none;
         border-radius: 0;
@@ -2631,6 +2632,7 @@ select, input[type="text"] {
 
     .image-editor-canvas {
         max-height: none;
+        min-height: 0;
         flex: 1;
     }
 


### PR DESCRIPTION
Fixes #639

## Summary
- Use `100dvh` (with `100vh` fallback) for the image editor modal height on mobile, so it accounts for browser chrome (address bar + toolbar) on iOS Safari
- Add `min-height: 0` to `.image-editor-canvas` in the mobile media query to override the base `min-height: 300px`, allowing the canvas to shrink so the footer buttons stay visible

## Test plan
- [ ] Open on iPhone Safari (or Chrome DevTools mobile emulator)
- [ ] Open image editor on a card
- [ ] Confirm Cancel and Done buttons are visible at the bottom
- [ ] Test both Crop & Rotate and Perspective tabs
- [ ] Test on desktop to confirm no regression

Preview: https://fix-image-editor-mobile-butt.sports-card-checklists.pages.dev