### PR TITLE
Add clear (x) button to search fields

### DIFF
--- a/index.html
+++ b/index.html
@@ -507,7 +507,7 @@
         </div>
 
         <div class="checklist-filter-bar" id="checklist-filter-bar" style="display: none;">
-            <input type="text" class="checklist-search" id="checklist-search" placeholder="Search checklists..." autocomplete="off">
+            <span class="search-wrapper"><input type="text" class="checklist-search" id="checklist-search" placeholder="Search checklists..." autocomplete="off"><button class="search-clear" type="button">&times;</button></span>
             <div class="checklist-filter-pills">
                 <button class="filter-pill active" data-filter="all">All</button>
                 <button class="filter-pill" data-filter="in-progress">In Progress</button>
@@ -811,6 +811,11 @@
             }
 
             searchInput.addEventListener('input', applyFilters);
+            document.querySelector('#checklist-filter-bar .search-clear')?.addEventListener('click', () => {
+                searchInput.value = '';
+                searchInput.focus();
+                applyFilters();
+            });
 
             pills.forEach(pill => {
                 pill.addEventListener('click', () => {

--- a/shared.css
+++ b/shared.css
@@ -651,6 +651,27 @@ select, input[type="text"] {
     font-weight: 500;
 }
 
+.search-wrapper {
+    position: relative;
+    display: inline-flex;
+    align-items: center;
+}
+.search-wrapper input { padding-right: 28px; }
+.search-clear {
+    position: absolute;
+    right: 6px;
+    background: none;
+    border: none;
+    cursor: pointer;
+    color: #999;
+    font-size: 16px;
+    padding: 2px 4px;
+    display: flex;
+    align-items: center;
+}
+.search-clear:hover { color: var(--color-text); }
+.search-wrapper input:placeholder-shown + .search-clear { display: none; }
+
 .filter-btn {
     font-family: 'Barlow', sans-serif;
     padding: 8px 14px;

--- a/src/checklist-engine.js
+++ b/src/checklist-engine.js
@@ -852,7 +852,7 @@ class ChecklistEngine {
         </select>`;
 
         // Search
-        html += `<input type="text" id="search" placeholder="Search cards...">`;
+        html += `<span class="search-wrapper"><input type="text" id="search" placeholder="Search cards..."><button class="search-clear" type="button">&times;</button></span>`;
 
         // Reorder button (visible when sort=Manual and user is owner)
         html += `<button id="reorder-btn" class="filter-btn" style="display:none">Reorder</button>`;
@@ -864,6 +864,10 @@ class ChecklistEngine {
             sel.addEventListener('change', () => this._onFilterChange());
         });
         container.querySelector('#search')?.addEventListener('input', () => this._onFilterChange());
+        container.querySelector('.search-clear')?.addEventListener('click', () => {
+            const input = container.querySelector('#search');
+            if (input) { input.value = ''; input.focus(); this._onFilterChange(); }
+        });
         container.querySelector('#reorder-btn')?.addEventListener('click', () => this._toggleReorderMode());
 
         // Show reorder button if applicable


### PR DESCRIPTION
## Summary
- Adds an x button to search inputs on both the index page and checklist pages
- Button appears only when text is present (CSS `:placeholder-shown`), no JS needed for visibility
- Clicking clears the input, re-focuses it, and re-triggers filtering

## Test plan
- [x] Checklist page: type in search, x appears, click to clear
- [x] Index page: type in search, x appears, click to clear
- [x] x is hidden when field is empty
- [x] Tested on mobile viewport