### PR TITLE
Fix index search bar not filling width on mobile

### DIFF
--- a/index.html
+++ b/index.html
@@ -449,8 +449,13 @@
                 flex-direction: column;
                 align-items: stretch;
             }
+            input.checklist-search {
+                width: 100%;
+                box-sizing: border-box;
+            }
             .checklist-filter-pills {
                 justify-content: center;
+                flex-wrap: wrap;
             }
         }
     </style>


### PR DESCRIPTION
## Summary
- Search input had a fixed `width: 200px` that didn't expand when the filter bar stacks vertically on mobile
- Now uses `width: 100%` with `box-sizing: border-box` at the `<500px` breakpoint
- Added `flex-wrap: wrap` to filter pills for narrow screens

Fixes #648

## Test plan
- [ ] On mobile (or narrow viewport < 500px), search bar fills the full width
- [ ] Filter pills wrap if viewport is too narrow for all four
- [ ] Desktop layout unchanged