### PR TITLE
Simplify deploy workflow to rely on push events only

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -3,9 +3,6 @@ name: Deploy to GitHub Pages
 on:
   push:
     branches: [main]
-  pull_request:
-    types: [closed]
-    branches: [main]
   workflow_dispatch:
   workflow_call:
 
@@ -13,28 +10,13 @@ permissions:
   contents: read
   pages: write
   id-token: write
-  actions: write
 
 concurrency:
   group: pages
   cancel-in-progress: true
 
 jobs:
-  # When a PR is merged, trigger deploy on main branch
-  trigger-deploy:
-    if: github.event_name == 'pull_request' && github.event.pull_request.merged == true
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-      - name: Trigger deploy workflow on main
-        run: gh workflow run deploy.yml --ref main
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
   build:
-    # Skip for PR events (trigger-deploy handles those)
-    if: github.event_name != 'pull_request'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -64,7 +46,6 @@ jobs:
           path: .
 
   deploy:
-    if: github.event_name != 'pull_request'
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}


### PR DESCRIPTION
## Summary
- Remove the `pull_request: closed` trigger and `trigger-deploy` job from `deploy.yml`.
- These were added Feb 2026 as a fallback when push events from `gh pr merge` were sometimes failing to fire the deploy workflow. They caused every PR merge to show a spurious cancelled check on the PR page due to the `pages` concurrency group.
- Push to main has reliably triggered the deploy across recent merges; the fallback isn't earning its noise.

## Test plan
- [ ] After merge, deploy workflow runs from the push to main and the site updates
- [ ] No more cancelled check appears on subsequent PRs