### PR TITLE
Prompt re-login when image upload hits an expired session

### DIFF
--- a/src/card-editor.js
+++ b/src/card-editor.js
@@ -959,10 +959,7 @@ class CardEditorModal {
             btn.title = 'Done! Image uploaded';
 
         } catch (error) {
-            if (error.message !== 'Cancelled') {
-                console.error('Image edit failed:', error);
-                alert('Failed to edit image: ' + error.message);
-            }
+            this._handleImageError(error, 'Image edit failed:', 'Failed to edit image: ');
         } finally {
             btn.classList.remove('processing');
             btn.disabled = false;
@@ -1050,11 +1047,7 @@ class CardEditorModal {
             btn.title = 'Done! Image uploaded';
 
         } catch (error) {
-            // Don't show error if user just cancelled
-            if (error.message !== 'Cancelled') {
-                console.error('Image processing failed:', error);
-                alert('Failed to process image: ' + error.message);
-            }
+            this._handleImageError(error, 'Image processing failed:', 'Failed to process image: ');
         } finally {
             btn.classList.remove('processing');
             btn.disabled = false;
@@ -1140,15 +1133,27 @@ class CardEditorModal {
             this.backdrop.querySelector('#editor-img-file').value = '';
 
         } catch (error) {
-            // Don't show error if user just cancelled
-            if (error.message !== 'Cancelled') {
-                console.error('Image upload failed:', error);
-                alert('Failed to upload image: ' + error.message);
-            }
+            this._handleImageError(error, 'Image upload failed:', 'Failed to upload image: ');
         } finally {
             zone.classList.remove('processing');
             this.setImageProcessing(false);
         }
+    }
+
+    // Centralized error handling for image upload/edit flows. Ignores user
+    // cancellations, prompts a clean re-login on an expired session, and falls
+    // back to a generic alert for everything else.
+    _handleImageError(error, logLabel, alertPrefix) {
+        if (error.message === 'Cancelled') return;
+        console.error(logLabel, error);
+        if (error.authExpired) {
+            if (confirm('Your session has expired. Sign in again to upload images?')) {
+                githubSync.logout();
+                window.location.reload();
+            }
+            return;
+        }
+        alert(alertPrefix + error.message);
     }
 
     // Set dirty state

--- a/src/github-sync.js
+++ b/src/github-sync.js
@@ -656,6 +656,14 @@ class GitHubSync {
         }
     }
 
+    // Build an error flagged as an expired session so callers can prompt a
+    // re-login instead of surfacing a cryptic "Invalid token" message.
+    _authExpiredError() {
+        const err = new Error('Your session has expired. Please sign in again.');
+        err.authExpired = true;
+        return err;
+    }
+
     // Upload an image to Cloudflare R2 via the Worker
     // Returns the full R2 URL on success, null on failure
     async uploadImage(key, base64Content) {
@@ -676,6 +684,9 @@ class GitHubSync {
 
         if (!response.ok) {
             const body = await response.json().catch(() => ({}));
+            if (response.status === 401 || response.status === 403) {
+                throw this._authExpiredError();
+            }
             if (body.error) {
                 throw new Error(body.error);
             }
@@ -701,6 +712,9 @@ class GitHubSync {
 
         if (!response.ok) {
             const body = await response.json().catch(() => ({}));
+            if (response.status === 401 || response.status === 403) {
+                throw this._authExpiredError();
+            }
             if (body.error) {
                 throw new Error(body.error);
             }

--- a/src/github-sync.js
+++ b/src/github-sync.js
@@ -684,7 +684,10 @@ class GitHubSync {
 
         if (!response.ok) {
             const body = await response.json().catch(() => ({}));
-            if (response.status === 401 || response.status === 403) {
+            // The Worker returns 401 only for an expired/invalid token. 403 is
+            // used for non-auth cases (preview-site block, unauthorized user),
+            // so it must fall through to the real error message below.
+            if (response.status === 401) {
                 throw this._authExpiredError();
             }
             if (body.error) {
@@ -712,7 +715,10 @@ class GitHubSync {
 
         if (!response.ok) {
             const body = await response.json().catch(() => ({}));
-            if (response.status === 401 || response.status === 403) {
+            // The Worker returns 401 only for an expired/invalid token. 403 is
+            // used for non-auth cases (preview-site block, unauthorized user),
+            // so it must fall through to the real error message below.
+            if (response.status === 401) {
                 throw this._authExpiredError();
             }
             if (body.error) {

--- a/tests/github-sync.test.js
+++ b/tests/github-sync.test.js
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeAll } from 'vitest';
+import { describe, it, expect, beforeAll, afterEach } from 'vitest';
 import { readFileSync } from 'fs';
 import { resolve } from 'path';
 
@@ -53,5 +53,38 @@ describe('GitHubSync._isRateLimited', () => {
     it('detects a 429 rate-limit response', async () => {
         const body = '{"message":"You have exceeded a secondary rate limit"}';
         expect(await sync._isRateLimited(mockResponse({ status: 429, body }))).toBe(true);
+    });
+});
+
+describe('GitHubSync image ops auth handling', () => {
+    const realFetch = globalThis.fetch;
+    afterEach(() => {
+        globalThis.fetch = realFetch;
+        sync.token = null;
+    });
+
+    // Worker response stand-in for image endpoints (they call response.json()).
+    function jsonResponse({ ok, status, body = {} }) {
+        return { ok, status, json: async () => body };
+    }
+
+    it('uploadImage flags an expired session on 401 so callers can prompt re-login', async () => {
+        sync.token = 'stale-token';
+        globalThis.fetch = async () => jsonResponse({ ok: false, status: 401, body: { error: 'Invalid token' } });
+        await expect(sync.uploadImage('images/x.webp', 'AAAA')).rejects.toMatchObject({ authExpired: true });
+    });
+
+    it('uploadImage does not flag non-auth failures as expired sessions', async () => {
+        sync.token = 'good-token';
+        globalThis.fetch = async () => jsonResponse({ ok: false, status: 500, body: { error: 'Boom' } });
+        const err = await sync.uploadImage('images/x.webp', 'AAAA').catch(e => e);
+        expect(err.message).toBe('Boom');
+        expect(err.authExpired).toBeFalsy();
+    });
+
+    it('deleteImage flags an expired session on 401', async () => {
+        sync.token = 'stale-token';
+        globalThis.fetch = async () => jsonResponse({ ok: false, status: 401, body: { error: 'Invalid token' } });
+        await expect(sync.deleteImage('images/x.webp')).rejects.toMatchObject({ authExpired: true });
     });
 });

--- a/tests/github-sync.test.js
+++ b/tests/github-sync.test.js
@@ -82,6 +82,14 @@ describe('GitHubSync image ops auth handling', () => {
         expect(err.authExpired).toBeFalsy();
     });
 
+    it('uploadImage does not flag a 403 (preview-site block / unauthorized user) as expired', async () => {
+        sync.token = 'good-token';
+        globalThis.fetch = async () => jsonResponse({ ok: false, status: 403, body: { error: 'Image uploads are disabled on preview sites.' } });
+        const err = await sync.uploadImage('images/x.webp', 'AAAA').catch(e => e);
+        expect(err.message).toBe('Image uploads are disabled on preview sites.');
+        expect(err.authExpired).toBeFalsy();
+    });
+
     it('deleteImage flags an expired session on 401', async () => {
         sync.token = 'stale-token';
         globalThis.fetch = async () => jsonResponse({ ok: false, status: 401, body: { error: 'Invalid token' } });


### PR DESCRIPTION
## Summary

When a stored GitHub OAuth token expires or is revoked, the Cloudflare Worker rejects image uploads with a 401. Previously this surfaced as a cryptic `Failed to process image: Invalid token` alert with no path to recover. The card-save flow already handles the same condition gracefully (`auth_expired` → "Session expired" banner with a Sign Out action); the image-upload flow did not.

This aligns image upload/edit/delete with that behavior:

- `github-sync.js`: `uploadImage()` and `deleteImage()` detect a **401** from the Worker and throw an error flagged `authExpired`, with a clear message. A **403** (preview-site block or unauthorized user) intentionally falls through to the Worker's real message, so it is never misreported as an expired session.
- `card-editor.js`: the three image-flow catch blocks share a new `_handleImageError()` helper. On an expired session it prompts the user to sign in again (logout + reload), mirroring the save-error flow, instead of showing a raw error.

## Test plan

- [x] `npm test` — full suite passes (88 tests), including new cases: 401 flags `authExpired`, 403 preview-block keeps its real message, and non-auth (500) failures stay unflagged
- [x] `npm run build` succeeds
- [ ] On the live site: let a session expire (or clear the token), attempt an image upload, confirm the re-login prompt appears and signing in restores upload
- [ ] On a preview site: confirm an upload still shows "Image uploads are disabled on preview sites." (not the re-login prompt)
- [ ] Confirm a normal (non-auth) upload failure still shows the generic error alert