### PR TITLE
Show live owned value on index checklist cards

### DIFF
--- a/index.html
+++ b/index.html
@@ -636,7 +636,7 @@
             const perChecklist = uniqueOwned?.perChecklist;
             if (!perChecklist) return;
             Object.entries(perChecklist).forEach(([id, value]) => {
-                const el = document.querySelector(`.checklist-card[data-checklist="${id}"] .value-owned`);
+                const el = document.querySelector(`.checklist-card[data-checklist="${CSS.escape(id)}"] .value-owned`);
                 if (el) el.textContent = '$' + Math.round(value) + ' value';
             });
         }

--- a/index.html
+++ b/index.html
@@ -629,6 +629,18 @@
             }
         }
 
+        // Patch each checklist card's owned value with the live figure (main +
+        // extra) so cards reflect extras immediately, without waiting for the
+        // checklist to re-save its stats to the gist.
+        function updateChecklistCardValues(uniqueOwned) {
+            const perChecklist = uniqueOwned?.perChecklist;
+            if (!perChecklist) return;
+            Object.entries(perChecklist).forEach(([id, value]) => {
+                const el = document.querySelector(`.checklist-card[data-checklist="${id}"] .value-owned`);
+                if (el) el.textContent = '$' + Math.round(value) + ' value';
+            });
+        }
+
         // Compute unique owned count by loading card data (gist is already cached, no extra API calls)
         async function computeUniqueOwned(entries) {
             try {
@@ -647,6 +659,7 @@
                 // main-only owned count it clamps (stats.owned).
                 const uniqueFPs = new Map();     // fingerprint -> highest price (main + extra)
                 const uniqueMainFPs = new Set(); // fingerprints of owned main-category cards
+                const perChecklistValue = {};    // id -> owned value (main + extra), for per-card display
                 for (const entry of entries) {
                     const ownedIds = allOwned[entry.id] || [];
                     if (ownedIds.length === 0) continue;
@@ -712,12 +725,16 @@
                         if (price > existing) uniqueFPs.set(fp, price);
                         else if (!uniqueFPs.has(fp)) uniqueFPs.set(fp, 0);
                         if (mainIds.has(id)) uniqueMainFPs.add(fp);
+                        // Per-checklist owned value is not de-duplicated: each card
+                        // shows its own full owned value (main + extra), matching the
+                        // checklist page's Est. Value.
+                        perChecklistValue[entry.id] = (perChecklistValue[entry.id] || 0) + price;
                     });
                 }
 
                 let uniqueValue = 0;
                 uniqueFPs.forEach(price => { uniqueValue += price; });
-                return { count: uniqueMainFPs.size, value: uniqueValue };
+                return { count: uniqueMainFPs.size, value: uniqueValue, perChecklist: perChecklistValue };
             } catch (e) {
                 console.warn('Failed to compute unique owned stats:', e);
                 return null;
@@ -887,6 +904,7 @@
             if (entries && entries.length > 0) initChecklistFilters();
             const uniqueOwned = await computeUniqueOwned(entries);
             updateAggregateStats(allStats, uniqueOwned);
+            updateChecklistCardValues(uniqueOwned);
 
             // Render nav links + hamburger (registry already cached by renderDynamicChecklists)
             await DynamicNav.init();


### PR DESCRIPTION
## Summary
Follow-up to #682. On the homepage, the per-checklist cards render their "$X value" line from each checklist's **stored** stats, which stay base-only until that checklist re-saves. This makes those cards show the **live** owned value (main + extra) immediately, matching the aggregate scoreboard and the checklist page.

- `computeUniqueOwned()` already loads every checklist's card data; it now also accumulates a per-checklist owned value (main + extra, `Math.round` at display) and returns it as `perChecklist`.
- New `updateChecklistCardValues()` patches each card's `.value-owned` text after render (same render-then-update pattern the aggregate uses). Null-safe (skips cards without the element) and falls back to the stored value if a checklist's data can't load.

## Notes
- Per-card values are intentionally **not** de-duplicated across checklists (each card shows its own full owned value, like its checklist page). The aggregate total remains de-duplicated, so for a card owned in two checklists the per-card values can sum to more than the aggregate — by design.
- Scope: only the **value** line is patched. Owned count, "$X to complete", and extra pills still come from stored stats (unchanged by the extras feature).

## Test plan
- [x] `npm test` — passing
- [x] Inline-script syntax check clean
- [ ] Live: a checklist with owned extra-category cards shows the extras-inclusive value on its index card without visiting it first
- [ ] Live: cards without stats ("No cards yet") and checklists whose data fails to load are unaffected
