### PR TITLE
Record testing and rendering conventions in CLAUDE.md

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -21,6 +21,8 @@
 - GitHub Pages deploys in ~30-60 seconds after push
 - After a PR is merged, wait for user to test before pushing more fixes - create new PRs instead of adding to old branches
 - **Unit tests** - Run `npm test` (vitest). Tests cover sanitize, CardRenderer, and CardEditorModal search term generation.
+- **Test fixtures must match what the editor actually submits** - tests that hand-build `cardData` for the engine, or stub `ChecklistManager`, routinely model shapes the real code never produces, which makes broken code look correct. Read `getFormData()`/`save()` in `card-editor.js` before writing one. Known traps: `save()` renames `ebay` -> `search` before calling `onSave`; `getCustomFieldData` skips any field the config doesn't declare; unchecked checkboxes are omitted entirely; a stub `ChecklistManager` that skips `onOwnedChange` hides the re-render that `toggleOwned` triggers. The contract is documented above `formDataWithCleared` in `tests/clear-field-merge.test.js`.
+- **Guard tests must assert a count, not just values** - a test that loops over `querySelectorAll(...)` passes trivially when it finds nothing. See `tests/external-link-rel.test.js`.
 - **Preview gist sync** - Before testing on Cloudflare preview sites, remind user to sync preview gist from production (login on preview site, use "Sync from Production" button). Otherwise data may be stale or have outdated schema.
 - **Preview URL format** - Cloudflare Pages converts branch names: slashes become dashes, then truncated to exactly 28 characters. Count AFTER converting slashes. Example: `fix/consolidate-search-toggles` -> `fix-consolidate-search-toggles` (30 chars) -> truncate to `fix-consolidate-search-toggl` (28 chars) -> `https://fix-consolidate-search-toggl.sports-card-checklists.pages.dev`
 
@@ -31,6 +33,12 @@
 - When making changes to a page or card component, consider applying the same change to all checklists/cards
 - The index page has multiple checklist cards (Jayden Daniels, Washington QBs) - features should be consistent across them
 - UI improvements, data displays, and styling should generally apply to all cards unless specifically scoped
+- **Fix sinks by class, not by instance** - when fixing an escaping, deletion-marker or inline-handler bug, enumerate every occurrence of the pattern before stopping. Past fixes repeatedly patched one site and left identical ones in adjacent files.
+
+## Rendering and escaping
+- **No inline event handlers in the card render path** - use a delegated listener on `#sections-container`, which persists across `renderCards()` (only its `innerHTML` is replaced). Image errors need a **capture-phase** listener; `error` does not bubble.
+- **Three escaping helpers, distinct jobs** - `sanitizeText` for text nodes (does NOT escape quotes), `sanitizeAttr` for attribute values (does), `sanitizeLinkUrl` for navigation targets (scheme allowlist only, resolves relative URLs against `document.baseURI` - it does not escape, so pair it with `sanitizeAttr`). Plain `sanitizeUrl` blanks relative URLs and is unusable for this app's hrefs.
+- **Deleting a card field requires a marker** - `_mergeCardArrays` merges `{...freshCard, ...localCard}` with the gist as base, so simply removing a key locally is undone on the next save. Deletions ride on `img: ''`, `noCard: false`, or the non-enumerable `_clearedKeys`, and only fields this checklist's editor manages may be recorded as cleared.
 
 ## GitHub Issues
 - When creating an issue, always add appropriate labels for **size** and **priority**


### PR DESCRIPTION
Records conventions that six PRs' worth of work surfaced, so the next session doesn't rediscover them.

Every line comes from something that actually cost time today.

## Testing

- **Fixtures must match what the editor actually submits.** Six separate times, a test modelled a shape the real code never produces and made broken code look correct. The specific traps are named: `save()` renames `ebay` → `search` before `onSave`; `getCustomFieldData` skips fields the config doesn't declare; unchecked checkboxes are omitted entirely; and a stub `ChecklistManager` that skips `onOwnedChange` hides the re-render `toggleOwned` triggers — which is exactly what concealed a block of dead code in #690.
- **Guard tests must assert a count.** A test looping over `querySelectorAll(...)` passes trivially when it finds nothing, which is how this kind of guard rots.

## Consistency

- **Fix sinks by class, not by instance.** The single most repeated failure: #687 removed one inline handler and left two identical ones in adjacent files; the falsy-value fix patched one of nine sinks; #690's dead code turned out to be a copy of the same pattern found again in #693.

## New "Rendering and escaping" section

- No inline event handlers in the card render path — delegated listener on `#sections-container`, and image errors need **capture phase** because `error` doesn't bubble.
- The three escaping helpers and their distinct jobs, including that `sanitizeLinkUrl` does **not** escape and must be paired with `sanitizeAttr`, and that plain `sanitizeUrl` blanks relative URLs so it's unusable for this app's hrefs.
- **Deleting a card field requires a marker.** `_mergeCardArrays` merges with the gist as base, so simply removing a key locally is undone on the next save. This one is genuinely non-obvious and caused two separate data-loss bugs today.

## Test plan

- [x] Read it and cut anything you disagree with

Docs only — no code, no tests, no behaviour change.
