### PR TITLE
Make filters agree with the card on over-owned checklists

### DIFF
--- a/index.html
+++ b/index.html
@@ -912,7 +912,15 @@
                         const total = match ? parseInt(match[2]) : 0;
                         const hasCards = total > 0;
 
-                        if (activeFilter === 'complete') matchesFilter = hasCards && owned === total;
+                        // Complete is owned >= total, matching the card's own test above,
+                        // not owned === total. A stale gist total can leave more cards
+                        // owned than the checklist lists, and on 12 of 10 the strict
+                        // equality matched none of the three filters - not Complete, not
+                        // In Progress, not Not Started - so a card the page was styling as
+                        // complete could only be found under All (#717). The three states
+                        // have to partition every owned/total pair; the hasCards guard is
+                        // what keeps an empty checklist out of Complete, since 0 >= 0.
+                        if (activeFilter === 'complete') matchesFilter = hasCards && owned >= total;
                         else if (activeFilter === 'in-progress') matchesFilter = hasCards && owned > 0 && owned < total;
                         else if (activeFilter === 'not-started') matchesFilter = !hasCards || owned === 0;
                     }

--- a/tests/index-a11y.test.js
+++ b/tests/index-a11y.test.js
@@ -1,94 +1,22 @@
 import { describe, it, expect, beforeEach } from 'vitest';
-import { readFileSync } from 'fs';
-import { resolve } from 'path';
-
-const sanitizeText = globalThis.sanitizeText;
-const isSafeColor = globalThis.isSafeColor;
+import {
+    CIRCUMFERENCE,
+    FILTER_BAR_MARKUP,
+    GRID_MARKUP,
+    loadInitChecklistFilters,
+    renderCard,
+} from './index-source.js';
 
 // index.html conveyed several states with a glyph and a colour and nothing else
 // (#703). The convention chosen for the whole page is ARIA roles and names on the
 // existing element - never visually-hidden text, because both this page and the
 // card grid filter on textContent, so hidden words would leak into search matches
-// and into the "N of M" parse in applyFilters below.
+// and into the "N of M" parse applyFilters does.
 
-// The markup and the two functions under test are all inline in index.html, which
-// tests/setup.js does not load (it only evals src/*.js). Extract the real source
-// and evaluate it so this asserts the shipped page rather than a copy. Same trick
-// as tests/index-stats-escaping.test.js and tests/index-aggregate-complete.test.js.
-const INDEX_HTML = readFileSync(resolve(import.meta.dirname, '..', 'index.html'), 'utf-8');
-
-// Bounds of the balanced {...} block opening at or after `from`.
-function balancedBlock(from) {
-    const bodyStart = INDEX_HTML.indexOf('{', from);
-    let depth = 0;
-    for (let i = bodyStart; i < INDEX_HTML.length; i++) {
-        if (INDEX_HTML[i] === '{') depth++;
-        else if (INDEX_HTML[i] === '}' && --depth === 0) return { bodyStart, end: i + 1 };
-    }
-    throw new Error('unbalanced block in index.html');
-}
-
-function sourceOf(marker) {
-    const start = INDEX_HTML.indexOf(marker);
-    if (start === -1) throw new Error(`${marker} not found in index.html`);
-    return { start, ...balancedBlock(start + marker.length - 1) };
-}
-
-// The element opened by `startTag`, up to its matching </div>.
-function markupOf(startTag) {
-    const start = INDEX_HTML.indexOf(startTag);
-    if (start === -1) throw new Error(`${startTag} not found in index.html`);
-
-    const tags = /<div\b|<\/div>/g;
-    tags.lastIndex = start;
-    let depth = 0;
-    let match;
-    while ((match = tags.exec(INDEX_HTML)) !== null) {
-        if (match[0] === '</div>') {
-            if (--depth === 0) return INDEX_HTML.slice(start, match.index + '</div>'.length);
-        } else {
-            depth++;
-        }
-    }
-    throw new Error(`unbalanced ${startTag} markup in index.html`);
-}
-
-const FILTER_BAR_MARKUP = markupOf('<div class="checklist-filter-bar"');
-const GRID_MARKUP = markupOf('<div class="checklist-grid">');
-
-const buildRenderCard = (() => {
-    const { bodyStart, end } = sourceOf('dynamicEntries.forEach(entry => {');
-    return new Function(
-        'allGistStats',
-        'PROGRESS_RING_CIRCUMFERENCE',
-        'grid',
-        'dynamicStats',
-        'sanitizeText',
-        'isSafeColor',
-        `return (entry) => ${INDEX_HTML.slice(bodyStart, end)};`,
-    );
-})();
-
-const loadInitChecklistFilters = () => {
-    const { start, end } = sourceOf('function initChecklistFilters() {');
-    return new Function(`${INDEX_HTML.slice(start, end)}; return initChecklistFilters;`)();
-};
-
-// Matches the r="20" circle in the card's SVG, as index.html's own constant does.
-const CIRCUMFERENCE = 2 * Math.PI * 20;
-
-// Render one registry entry through the real card builder and hand back the card.
-function renderCard(entry, stats, grid = document.createElement('div')) {
-    buildRenderCard(
-        { [entry.id]: stats },
-        CIRCUMFERENCE,
-        grid,
-        {},
-        sanitizeText,
-        isSafeColor,
-    )(entry);
-    return grid.querySelector('.checklist-card:last-of-type');
-}
+// The markup and the functions under test are all inline in index.html, which
+// tests/setup.js does not load (it only evals src/*.js). The imports above slice
+// the real source out and evaluate it, so this asserts the shipped page rather
+// than a copy - see tests/index-source.js.
 
 // How much of the ring is dashed out, i.e. the unfilled part of the arc.
 const ringOffset = (card) =>

--- a/tests/index-filter-coverage.test.js
+++ b/tests/index-filter-coverage.test.js
@@ -1,0 +1,160 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import {
+    FILTER_BAR_MARKUP,
+    GRID_MARKUP,
+    loadInitChecklistFilters,
+    renderCard,
+} from './index-source.js';
+
+// The index page's three state filters have to partition the checklists: every
+// card belongs to exactly one of In Progress, Complete and Not Started, whatever
+// owned/total it carries.
+//
+// That invariant broke on an over-owned checklist (#717). The card decides
+// completeness with owned >= total, but applyFilters used owned === total for
+// Complete and owned > 0 && owned < total for In Progress, so 12 of 10 rendered
+// as complete and then matched no filter at all - it could only be found under
+// All. Over-owned is a state the gist can genuinely hold: computeStats derives
+// owned and total in one pass over the same cards and can never emit one, but a
+// stored total goes stale, and it is only recomputed when the owner opens that
+// checklist page while signed in (_refreshStatsIfStale in checklist-engine.js).
+// Until then the index page keeps showing the figure it was given.
+//
+// The sweep below is the guard: it asserts the partition holds across the whole
+// owned/total space rather than spot-checking the one pair that broke, so the
+// next classification gap fails here too. The named cases underneath pin which
+// filter each state belongs to, which the sweep alone would not catch.
+
+const ENTRY = { id: 'test', title: 'Test Checklist', type: 'dynamic' };
+const stats = (owned, total) => ({ owned, total, ownedValue: 0, neededValue: 0 });
+
+const STATE_FILTERS = ['in-progress', 'complete', 'not-started'];
+
+// Mount the real filter bar over a grid holding one real card, then click every
+// pill and report which filters leave the card visible.
+function filtersMatching(cardStats) {
+    document.body.innerHTML = FILTER_BAR_MARKUP + GRID_MARKUP;
+    const grid = document.querySelector('.checklist-grid');
+    const card = renderCard(ENTRY, cardStats, grid);
+    loadInitChecklistFilters()();
+
+    const pills = [...document.querySelectorAll('.filter-pill')];
+    expect(pills).toHaveLength(4);
+
+    const matched = [];
+    for (const pill of pills) {
+        pill.click();
+        if (card.style.display !== 'none') matched.push(pill.dataset.filter);
+    }
+    return matched;
+}
+
+// The single state filter a card falls under, or null if it slipped through all
+// three - which is the failure #717 was.
+function stateFilterFor(cardStats) {
+    const matched = filtersMatching(cardStats).filter(f => STATE_FILTERS.includes(f));
+    return matched.length === 1 ? matched[0] : null;
+}
+
+beforeEach(() => {
+    document.body.innerHTML = '';
+});
+
+describe('index.html filters — every checklist lands in exactly one state', () => {
+    // Deliberately runs past total: owned > total is the region that broke, and a
+    // sweep that stopped at total would have passed all along.
+    const pairs = [];
+    for (let total = 0; total <= 4; total++) {
+        for (let owned = 0; owned <= 6; owned++) pairs.push([owned, total]);
+    }
+
+    it.each(pairs)('%i of %i matches exactly one state filter', (owned, total) => {
+        const matched = filtersMatching(stats(owned, total));
+
+        expect(matched.filter(f => STATE_FILTERS.includes(f))).toHaveLength(1);
+    });
+
+    it.each(pairs)('%i of %i is always reachable under All', (owned, total) => {
+        expect(filtersMatching(stats(owned, total))).toContain('all');
+    });
+
+    it('covers the whole space rather than a handful of pairs', () => {
+        // Guards the loop bounds above: shrinking them would quietly narrow the
+        // sweep while every case still passed.
+        expect(pairs).toHaveLength(35);
+        expect(pairs.filter(([owned, total]) => total > 0 && owned > total)).toHaveLength(14);
+    });
+});
+
+describe('index.html filters — which state each checklist lands in', () => {
+    it('files an untouched checklist under Not Started', () => {
+        expect(stateFilterFor(stats(0, 10))).toBe('not-started');
+    });
+
+    it('files a partly collected checklist under In Progress', () => {
+        expect(stateFilterFor(stats(3, 10))).toBe('in-progress');
+    });
+
+    it('files an exactly finished checklist under Complete', () => {
+        expect(stateFilterFor(stats(10, 10))).toBe('complete');
+    });
+
+    it('files an over-owned checklist under Complete, as its card is already styled', () => {
+        // The regression. A stale total can leave more cards owned than listed;
+        // the card renders complete, so Complete is where it has to be findable.
+        const card = renderCard(ENTRY, stats(12, 10));
+        expect(card.classList.contains('complete')).toBe(true);
+
+        expect(stateFilterFor(stats(12, 10))).toBe('complete');
+    });
+
+    it('files an empty checklist under Not Started, not Complete', () => {
+        // 0 of 0 satisfies owned >= total, so only the hasCards guard keeps a
+        // checklist with nothing in it out of Complete.
+        expect(stateFilterFor(stats(0, 0))).toBe('not-started');
+    });
+
+    it('files a checklist with no stats at all under Not Started', () => {
+        // No stats renders "No cards yet" and no progress text for applyFilters to
+        // parse, so the missing-figures path has to classify too.
+        const card = renderCard(ENTRY, null);
+        expect(card.querySelectorAll('.progress-main-text')).toHaveLength(0);
+
+        expect(stateFilterFor(null)).toBe('not-started');
+    });
+});
+
+describe('index.html filters — the page does not disown a matching card', () => {
+    it('does not report "no matches" while showing an over-owned card under Complete', () => {
+        // The user-visible half of the bug: the only checklist in the grid matched
+        // nothing, so Complete emptied the grid and announced no matches.
+        document.body.innerHTML = FILTER_BAR_MARKUP + GRID_MARKUP;
+        const grid = document.querySelector('.checklist-grid');
+        renderCard(ENTRY, stats(12, 10), grid);
+        loadInitChecklistFilters()();
+
+        document.querySelector('.filter-pill[data-filter="complete"]').click();
+
+        const visible = [...grid.querySelectorAll('.checklist-card')]
+            .filter(c => c.style.display !== 'none');
+        expect(visible).toHaveLength(1);
+        expect(document.getElementById('checklist-no-results').textContent).toBe('');
+    });
+
+    it('still empties the grid when a filter genuinely matches nothing', () => {
+        // Pins that the assertion above is not satisfied by a filter that stopped
+        // hiding anything.
+        document.body.innerHTML = FILTER_BAR_MARKUP + GRID_MARKUP;
+        const grid = document.querySelector('.checklist-grid');
+        renderCard(ENTRY, stats(12, 10), grid);
+        loadInitChecklistFilters()();
+
+        document.querySelector('.filter-pill[data-filter="not-started"]').click();
+
+        const visible = [...grid.querySelectorAll('.checklist-card')]
+            .filter(c => c.style.display !== 'none');
+        expect(visible).toHaveLength(0);
+        expect(document.getElementById('checklist-no-results').textContent)
+            .toBe('No checklists match your search.');
+    });
+});

--- a/tests/index-source.js
+++ b/tests/index-source.js
@@ -1,0 +1,95 @@
+// Shared extract-and-evaluate helpers for the inline code in index.html, used by
+// tests/index-a11y.test.js and tests/index-filter-coverage.test.js.
+//
+// Not named *.test.js, so vitest's default include does not collect it as a suite.
+//
+// index.html is a page, not a module: the card builder and the filter logic are
+// inline <script> and tests/setup.js does not load them (it only evals src/*.js).
+// Rather than restate either in a test, these helpers slice the real source out of
+// the shipped file and evaluate it, so a test asserts what the page actually does.
+//
+// One copy rather than one per file on purpose - the same reasoning as
+// tests/dom-helpers.js. The balanced-brace scanning below is fiddly enough that
+// two copies would drift, and a slicer that silently grabs the wrong span still
+// produces a passing suite.
+
+import { readFileSync } from 'fs';
+import { resolve } from 'path';
+
+export const INDEX_HTML = readFileSync(resolve(import.meta.dirname, '..', 'index.html'), 'utf-8');
+
+// Bounds of the balanced {...} block opening at or after `from`.
+function balancedBlock(from) {
+    const bodyStart = INDEX_HTML.indexOf('{', from);
+    let depth = 0;
+    for (let i = bodyStart; i < INDEX_HTML.length; i++) {
+        if (INDEX_HTML[i] === '{') depth++;
+        else if (INDEX_HTML[i] === '}' && --depth === 0) return { bodyStart, end: i + 1 };
+    }
+    throw new Error('unbalanced block in index.html');
+}
+
+export function sourceOf(marker) {
+    const start = INDEX_HTML.indexOf(marker);
+    if (start === -1) throw new Error(`${marker} not found in index.html`);
+    return { start, ...balancedBlock(start + marker.length - 1) };
+}
+
+// The element opened by `startTag`, up to its matching </div>.
+export function markupOf(startTag) {
+    const start = INDEX_HTML.indexOf(startTag);
+    if (start === -1) throw new Error(`${startTag} not found in index.html`);
+
+    const tags = /<div\b|<\/div>/g;
+    tags.lastIndex = start;
+    let depth = 0;
+    let match;
+    while ((match = tags.exec(INDEX_HTML)) !== null) {
+        if (match[0] === '</div>') {
+            if (--depth === 0) return INDEX_HTML.slice(start, match.index + '</div>'.length);
+        } else {
+            depth++;
+        }
+    }
+    throw new Error(`unbalanced ${startTag} markup in index.html`);
+}
+
+export const FILTER_BAR_MARKUP = markupOf('<div class="checklist-filter-bar"');
+export const GRID_MARKUP = markupOf('<div class="checklist-grid">');
+
+// Matches the r="20" circle in the card's SVG, as index.html's own constant does.
+export const CIRCUMFERENCE = 2 * Math.PI * 20;
+
+const buildRenderCard = (() => {
+    const { bodyStart, end } = sourceOf('dynamicEntries.forEach(entry => {');
+    return new Function(
+        'allGistStats',
+        'PROGRESS_RING_CIRCUMFERENCE',
+        'grid',
+        'dynamicStats',
+        'sanitizeText',
+        'isSafeColor',
+        `return (entry) => ${INDEX_HTML.slice(bodyStart, end)};`,
+    );
+})();
+
+export const loadInitChecklistFilters = () => {
+    const { start, end } = sourceOf('function initChecklistFilters() {');
+    return new Function(`${INDEX_HTML.slice(start, end)}; return initChecklistFilters;`)();
+};
+
+// Render one registry entry through the real card builder and hand back the card.
+// The sanitize helpers come off globalThis at call time, not module load: setup.js
+// evals src/*.js before test modules, but reading them lazily keeps this module
+// importable regardless of that ordering.
+export function renderCard(entry, stats, grid = document.createElement('div')) {
+    buildRenderCard(
+        { [entry.id]: stats },
+        CIRCUMFERENCE,
+        grid,
+        {},
+        globalThis.sanitizeText,
+        globalThis.isSafeColor,
+    )(entry);
+    return grid.querySelector('.checklist-card:last-of-type');
+}

--- a/tests/index-source.js
+++ b/tests/index-source.js
@@ -12,27 +12,69 @@
 // tests/dom-helpers.js. The balanced-brace scanning below is fiddly enough that
 // two copies would drift, and a slicer that silently grabs the wrong span still
 // produces a passing suite.
+//
+// Being shared raises the stakes: a silent-failure path here would reach every
+// index.html suite at once. The failure modes are pinned in
+// tests/index-source.test.js - run those after changing anything below, since a
+// slicer that quietly stops slicing correctly reports success everywhere.
 
 import { readFileSync } from 'fs';
 import { resolve } from 'path';
 
 export const INDEX_HTML = readFileSync(resolve(import.meta.dirname, '..', 'index.html'), 'utf-8');
 
-// Bounds of the balanced {...} block opening at or after `from`.
-function balancedBlock(from) {
-    const bodyStart = INDEX_HTML.indexOf('{', from);
-    let depth = 0;
-    for (let i = bodyStart; i < INDEX_HTML.length; i++) {
-        if (INDEX_HTML[i] === '{') depth++;
-        else if (INDEX_HTML[i] === '}' && --depth === 0) return { bodyStart, end: i + 1 };
+// Bounds of the balanced {...} block opening at or after `from` in `source`.
+//
+// What this guarantees: it either returns a span whose braces balance, or it
+// throws naming the offset. It never returns a span it is unsure of. Both throws
+// matter - before the guard below, a `from` with no brace after it left indexOf
+// returning -1, the scan started at i = -1 and locked onto the *first* brace in
+// the whole file, and the caller got a plausible-looking span that sliced to the
+// empty string (#718). Silence was the bug, not the wrong answer.
+//
+// What it does not do: skip braces inside string literals, template literals,
+// regexes or comments - it is a brace counter, not a parser. Measured, with each
+// case pinned in tests/index-source.test.js:
+//
+//   - a stray `}` truncates the span, and does NOT throw. This is the one case it
+//     can still get wrong. In practice the truncation lands mid-token, so the
+//     consumer's `new Function` reports an unterminated string rather than a
+//     silent pass - but that is the consumer catching it, not this function.
+//   - a stray `{` only mis-slices if a surplus bare `}` appears later to absorb
+//     it. index.html is brace-balanced, so there is none: depth never returns to
+//     zero, the scan runs to the end and throws.
+//
+// So a mis-slice is caught downstream, not here: every span taken from this file
+// is immediately compiled by `new Function` or parsed as markup. That safety
+// belongs to the callers - keep it that way when adding one, and do not add a
+// consumer that merely eyeballs the slice.
+//
+// `source` is a parameter rather than a closure over INDEX_HTML so the failure
+// modes above can be tested on synthetic input instead of only on the real page.
+export function balancedBlock(source, from, label = 'index.html') {
+    const bodyStart = source.indexOf('{', from);
+    if (bodyStart === -1) {
+        throw new Error(
+            `no '{' at or after offset ${from} in ${label}, so there is no block to extract; `
+            + `text there: ${JSON.stringify(source.slice(from, from + 60))}`,
+        );
     }
-    throw new Error('unbalanced block in index.html');
+
+    let depth = 0;
+    for (let i = bodyStart; i < source.length; i++) {
+        if (source[i] === '{') depth++;
+        else if (source[i] === '}' && --depth === 0) return { bodyStart, end: i + 1 };
+    }
+    throw new Error(
+        `unbalanced block opening at offset ${bodyStart} in ${label}: `
+        + `${depth} brace(s) still open at end of input`,
+    );
 }
 
 export function sourceOf(marker) {
     const start = INDEX_HTML.indexOf(marker);
     if (start === -1) throw new Error(`${marker} not found in index.html`);
-    return { start, ...balancedBlock(start + marker.length - 1) };
+    return { start, ...balancedBlock(INDEX_HTML, start + marker.length - 1) };
 }
 
 // The element opened by `startTag`, up to its matching </div>.

--- a/tests/index-source.test.js
+++ b/tests/index-source.test.js
@@ -1,0 +1,153 @@
+import { describe, it, expect } from 'vitest';
+import { INDEX_HTML, balancedBlock, markupOf, sourceOf } from './index-source.js';
+
+// Self-tests for the shared slicer in tests/index-source.js.
+//
+// It is shared by every index.html suite, so a silent-failure path in it reaches
+// all of them at once - a wrong span that still reads as coverage. It had one:
+// with no `{` at or after the offset, indexOf returned -1, the scan started at
+// i = -1 and locked onto the *first* brace in the whole file, and the caller got
+// a plausible-looking span that sliced to the empty string (#718).
+//
+// These tests pin both what it refuses to do and the one case it still gets
+// wrong, so the limitation is documented behaviour rather than a latent surprise.
+// A slicer that stops slicing correctly reports success everywhere, so treat a
+// failure here as invalidating the other index.html suites too.
+
+const OFFSET_OF = (src, needle) => src.indexOf(needle);
+
+describe('balancedBlock — spans it can find', () => {
+    it('returns the outermost block, counting nested braces', () => {
+        const src = 'x = { a: { b: 1 }, c: 2 }; tail';
+
+        const { bodyStart, end } = balancedBlock(src, OFFSET_OF(src, '{'), 'probe');
+
+        expect(src.slice(bodyStart, end)).toBe('{ a: { b: 1 }, c: 2 }');
+    });
+
+    it('starts at the first brace at or after the offset, not at the offset itself', () => {
+        // Callers pass the offset of a marker, and the brace is generally a few
+        // characters further on.
+        const src = 'function f() { body(); } tail';
+
+        const { bodyStart } = balancedBlock(src, 0, 'probe');
+
+        expect(bodyStart).toBe(OFFSET_OF(src, '{'));
+    });
+});
+
+describe('balancedBlock — failures it refuses to guess at', () => {
+    it('throws instead of scanning from -1 when no brace follows the offset', () => {
+        // The #718 guard. Without it indexOf's -1 became the loop's start index,
+        // every read before index 0 was undefined, and the scan silently picked up
+        // the first brace in the file instead.
+        const src = 'nothing here';
+
+        expect(() => balancedBlock(src, 3, 'probe')).toThrow(/no '\{' at or after offset 3/);
+    });
+
+    it('names the offset and quotes the text there, so the miss is diagnosable', () => {
+        const src = 'alpha beta gamma';
+
+        expect(() => balancedBlock(src, 6, 'probe')).toThrow(/probe/);
+        expect(() => balancedBlock(src, 6, 'probe')).toThrow(/beta gamma/);
+    });
+
+    it('throws rather than returning a truncated span when a block never closes', () => {
+        const src = 'f() { a(); g();';
+
+        expect(() => balancedBlock(src, OFFSET_OF(src, '{'), 'probe'))
+            .toThrow(/unbalanced block opening at offset 4/);
+    });
+
+    it('throws on a stray opening brace, because nothing later closes it', () => {
+        // A `{` inside a string inflates the depth permanently. index.html is
+        // brace-balanced, so no surplus `}` exists to absorb it and the scan runs
+        // to the end - which is why this direction fails loudly rather than
+        // returning a too-long span.
+        const src = "f() { const s = '{'; g(); }\nif (x) { y(); }";
+
+        expect(() => balancedBlock(src, OFFSET_OF(src, '{'), 'probe'))
+            .toThrow(/still open at end of input/);
+    });
+});
+
+describe('balancedBlock — the case it still gets wrong', () => {
+    it('truncates at a stray closing brace inside a string, without throwing', () => {
+        // Pinned deliberately: this is a brace counter, not a parser, and this is
+        // the one input that yields a wrong answer quietly. Documented here so the
+        // limitation is visible; if it is ever fixed, this test should change on
+        // purpose rather than start failing mysteriously.
+        const src = "f() { const s = '}'; g(); } tail";
+
+        const { bodyStart, end } = balancedBlock(src, OFFSET_OF(src, '{'), 'probe');
+
+        expect(src.slice(bodyStart, end)).toBe("{ const s = '}");
+    });
+
+    it('leaves that truncated span un-compilable, which is what catches it downstream', () => {
+        // The safety net is the consumer, not the slicer: every span this module
+        // hands out is immediately compiled. A truncation lands mid-token, so the
+        // compile fails instead of the suite passing on a wrong extraction.
+        const src = "f() { const s = '}'; g(); } tail";
+        const { bodyStart, end } = balancedBlock(src, OFFSET_OF(src, '{'), 'probe');
+
+        expect(() => new Function(src.slice(bodyStart, end))).toThrow(SyntaxError);
+    });
+
+    it('mis-slices a stray opening brace only when a surplus closer absorbs it', () => {
+        // Completes the picture from the throwing case above: the stray `{` is
+        // harmless only because index.html has no unmatched `}`. Given one, the
+        // span silently runs long.
+        const src = "f() { const s = '{'; g(); }\n}";
+
+        const { bodyStart, end } = balancedBlock(src, OFFSET_OF(src, '{'), 'probe');
+
+        expect(src.slice(bodyStart, end)).toBe("{ const s = '{'; g(); }\n}");
+    });
+});
+
+describe('sourceOf — the same guards, reached through the real page', () => {
+    it('finds the blocks the index.html suites depend on', () => {
+        // Positive control. Without it every assertion below would also pass
+        // against a sourceOf that threw unconditionally.
+        const { start, bodyStart, end } = sourceOf('function initChecklistFilters() {');
+
+        expect(start).toBeGreaterThan(-1);
+        expect(bodyStart).toBeGreaterThan(start);
+        expect(end).toBeGreaterThan(bodyStart);
+        expect(INDEX_HTML.slice(start, end)).toContain('function applyFilters()');
+        expect(INDEX_HTML.slice(start, end).endsWith('}')).toBe(true);
+    });
+
+    it('throws for a marker that is not in the page at all', () => {
+        expect(() => sourceOf('function noSuchFunction() {'))
+            .toThrow(/function noSuchFunction\(\) \{ not found in index\.html/);
+    });
+
+    it('throws for a marker with no block after it, rather than slicing to nothing', () => {
+        // The end-to-end shape of #718: a real marker at the very end of the file.
+        // Before the guard this returned { bodyStart: -1, end: 1072 } - a span
+        // pointing at the stylesheet at the top of the page - and sliced to ''.
+        const marker = '</html>';
+        expect(INDEX_HTML.indexOf(marker)).toBeGreaterThan(-1);
+        expect(INDEX_HTML.indexOf('{', INDEX_HTML.indexOf(marker))).toBe(-1);
+
+        expect(() => sourceOf(marker)).toThrow(/no '\{' at or after offset/);
+    });
+});
+
+describe('markupOf — the matching guards on the element slicer', () => {
+    it('returns the element and its descendants, balanced', () => {
+        const markup = markupOf('<div class="checklist-filter-bar"');
+
+        expect(markup.startsWith('<div class="checklist-filter-bar"')).toBe(true);
+        expect(markup.endsWith('</div>')).toBe(true);
+        expect(markup.match(/<div\b/g)).toHaveLength(markup.match(/<\/div>/g).length);
+    });
+
+    it('throws for a start tag that is not in the page', () => {
+        expect(() => markupOf('<div class="no-such-element"'))
+            .toThrow(/not found in index\.html/);
+    });
+});


### PR DESCRIPTION
Closes #717.

## The bug

The card and the filters disagreed about over-owned checklists:

- the **card** used `owned >= total`, so it rendered as complete
- **`applyFilters`** used `owned === total` for Complete and `owned > 0 && owned < total` for In Progress

So 12 of 10 rendered as complete while matching **neither Complete, nor In Progress, nor Not Started** — visible only under All.

Fixed by making `applyFilters` use `owned >= total`, consistent with the card.

## Honest scope — this is defensive, not a live bug

No over-owned data exists. All 11 checklists in the gist are consistent (35/35, 11/39, 19/32, …), and the implementer could find **no code path that creates** an over-owned stored value: `computeStats` derives owned and total in one pass over the same cards, and every write persists the pair atomically.

So this closes a classification gap rather than a symptom anyone is seeing.

## But the stale total genuinely can persist

Worth recording, because the issue asked whether this was transient and the answer is no. `_refreshStatsIfStale` does re-save when computed stats differ from stored ones — but it's gated on being logged in **as the owner**, so it only fires when you open that specific checklist page. The index page reads `gistData.stats` verbatim with no refresh. A stale figure can therefore sit there indefinitely.

## Why option 1 rather than recomputing the total

Recomputing on the index would mean a second implementation of `computeStats`'s total. The nearest existing data (`mainIds` in `computeUniqueOwned`) excludes `collectionLink` and `noCard` cards that the engine *does* count, and skips zero-owned checklists entirely — so it would introduce a **new** index-vs-checklist disagreement while fixing this one. Bigger than this issue, and deliberately left rather than half-done.

## The test is the real value here

`tests/index-filter-coverage.test.js` — 79 tests. A sweep of owned 0–6 × total 0–4 asserting **exactly one** state filter matches each pair, plus named cases for 0-of-N, mid, N-of-N, over-owned, 0-of-0 and no-stats.

That's the invariant that actually broke — every checklist must match at least one filter — and it will catch the next classification gap rather than just this one. Reverting `index.html` produces exactly 16 failures (14 over-owned pairs plus 2 named cases).

## One thing wider than the fix

The extract-and-evaluate helpers moved from `index-a11y.test.js` into a shared `tests/index-source.js`, rather than a third copy of the brace parser being made. `tests/dom-helpers.js` exists because duplicating a test helper caused a real blind spot in #711, so copying it again seemed like the wrong direction. `index-a11y.test.js`'s 20 tests are unchanged and passing. Easy to drop if you'd rather keep this PR to the one operator.

639 tests (was 560). `index.html` isn't bundled, so no `dist` diff — confirmed.
