### PR TITLE
Load the same source files under test as in the bundle

### DIFF
--- a/build-manifest.js
+++ b/build-manifest.js
@@ -1,0 +1,27 @@
+// Which src/ files go into which bundle.
+//
+// This lives on its own, with no dependencies, because two very different
+// consumers need it: build.js (which pulls in esbuild) and tests/setup.js
+// (which runs inside jsdom, where esbuild refuses to load). Keeping the lists
+// here means the browser and the test run cannot load different files.
+
+// Concatenated in this order into dist/app.min.js. Order matters: they are
+// plain globals, not modules, and github-sync.js reads window.location at load.
+const sharedFiles = [
+  'github-sync.js',
+  'shared.js',
+  'collapsible-sections.js',
+  'card-renderer.js',
+  'checklist-manager.js',
+  'image-editor.js',
+  'card-editor.js',
+  'shopping-list.js',
+  'nav.js',
+  'checklist-creator.js',
+];
+
+// Built separately into dist/checklist-engine.min.js. checklist.html loads it as
+// its own script, so at runtime it shares no scope with the concatenation above.
+const engineFile = 'checklist-engine.js';
+
+module.exports = { sharedFiles, engineFile };

--- a/build.js
+++ b/build.js
@@ -2,20 +2,11 @@ const esbuild = require('esbuild');
 const fs = require('fs');
 const path = require('path');
 
-// Shared JS files in load order (globals, not ES modules)
+// Which files go into which bundle, shared with tests/setup.js so the test run
+// loads exactly what the browser gets. See build-manifest.js.
+const { sharedFiles, engineFile } = require('./build-manifest');
+
 const srcDir = path.join(__dirname, 'src');
-const sharedFiles = [
-  'github-sync.js',
-  'shared.js',
-  'collapsible-sections.js',
-  'card-renderer.js',
-  'checklist-manager.js',
-  'image-editor.js',
-  'card-editor.js',
-  'shopping-list.js',
-  'nav.js',
-  'checklist-creator.js',
-];
 
 async function build() {
   const distDir = path.join(__dirname, 'dist');
@@ -34,7 +25,7 @@ async function build() {
   fs.writeFileSync(path.join(distDir, 'app.min.js'), appResult.code);
 
   // Minify checklist-engine.js -> dist/checklist-engine.min.js
-  const engineSrc = fs.readFileSync(path.join(srcDir, 'checklist-engine.js'), 'utf8');
+  const engineSrc = fs.readFileSync(path.join(srcDir, engineFile), 'utf8');
   const engineResult = await esbuild.transform(engineSrc, {
     minify: true,
     target: 'es2020',

--- a/tests/bundle-file-lists.test.js
+++ b/tests/bundle-file-lists.test.js
@@ -1,0 +1,69 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync, readdirSync } from 'fs';
+import { resolve } from 'path';
+import { createRequire } from 'module';
+
+import { files as setupFiles } from './setup.js';
+
+// build.js and tests/setup.js once carried separate copies of the src/ load order,
+// and they had drifted: github-sync.js was in the bundle but not in the test run
+// (#713). Both now read build-manifest.js, so that particular pair cannot diverge
+// again. What can still diverge is src/ itself against the manifest, and setup.js
+// against the manifest if someone re-inlines the list. This covers both.
+//
+// Note this compares *data* - arrays of filenames, and which globals the loaded
+// files actually published - rather than asserting on the text of the source, which
+// is the pattern #711 removed.
+
+const ROOT = resolve(import.meta.dirname, '..');
+const SRC = resolve(ROOT, 'src');
+const { sharedFiles, engineFile } = createRequire(import.meta.url)('../build-manifest.js');
+
+// The two bundles build.js emits. They are deliberately different things:
+// sharedFiles are concatenated into dist/app.min.js and so share one scope, while
+// engineFile becomes dist/checklist-engine.min.js, a script checklist.html loads by
+// itself. setup.js loads both because tests exercise both.
+const bundled = [...sharedFiles, engineFile];
+
+describe('bundle file lists', () => {
+    // An unbundled src file is dead code that ships to nobody. The reverse - a
+    // manifest entry with no file behind it - in practice takes the whole run down
+    // first, since setup.js reads each listed file; this is the assertion that names
+    // it if it somehow gets this far.
+    it('covers every file in src/, and only files in src/', () => {
+        const onDisk = readdirSync(SRC).filter(f => f.endsWith('.js')).sort();
+        expect([...bundled].sort()).toEqual(onDisk);
+    });
+
+    // Trivially true while setup.js derives its list from the manifest. It exists so
+    // that re-inlining the list there fails here instead of silently shrinking what
+    // the suite loads, which is how #713 happened. Reordering the manifest is not
+    // drift and is not caught here: both consumers move together, by construction.
+    it('is the same list tests/setup.js loads, in the same order', () => {
+        expect(setupFiles).toEqual(bundled);
+    });
+});
+
+// Column-0 `window.X =`, which is how every src file publishes its globals. Anchored
+// at column 0 so an assignment inside a function or a comment is not picked up.
+function windowExports(file) {
+    const code = readFileSync(resolve(SRC, file), 'utf-8');
+    return [...code.matchAll(/^window\.([A-Za-z_$][\w$]*)\s*=/gm)].map(m => m[1]);
+}
+
+describe('the shared setup actually loads each bundled file', () => {
+    // Asserting on the file list alone would not notice a file that is listed but
+    // fails to eval, so check the observable result: something each file publishes is
+    // on window. github-sync.js is the reason this is here - it was the file missing
+    // from setup.js, so window.githubSync was absent for every test.
+    const expectations = bundled.map(file => [file, windowExports(file)]);
+
+    it.each(expectations)('%s publishes at least one global to key off', (_file, exports) => {
+        // Guards the check below from passing vacuously for a file with no matches.
+        expect(exports.length).toBeGreaterThan(0);
+    });
+
+    it.each(expectations)('%s is loaded (its globals resolve)', (_file, exports) => {
+        expect(exports.filter(name => !(name in globalThis.window))).toEqual([]);
+    });
+});

--- a/tests/github-sync.test.js
+++ b/tests/github-sync.test.js
@@ -1,14 +1,11 @@
 import { describe, it, expect, beforeAll, afterEach } from 'vitest';
-import { readFileSync } from 'fs';
-import { resolve } from 'path';
 
-// github-sync.js isn't loaded by the shared setup (it instantiates a singleton
-// and touches the network), so load it here in isolation to exercise its
-// pure-ish error classification logic.
+// The shared setup loads github-sync.js along with the rest of the bundle (#713),
+// so this exercises the real singleton rather than a re-loaded copy. Constructing
+// it touches localStorage but not the network; the tests below stub fetch for the
+// paths that would make a request.
 let sync;
 beforeAll(() => {
-    const code = readFileSync(resolve(import.meta.dirname, '..', 'src', 'github-sync.js'), 'utf-8');
-    (0, eval)(code);
     sync = globalThis.window.githubSync;
 });
 

--- a/tests/no-network.test.js
+++ b/tests/no-network.test.js
@@ -1,0 +1,42 @@
+import { describe, it, expect } from 'vitest';
+
+import { takeAttemptedRequests } from './setup.js';
+
+// tests/setup.js replaces fetch with a tripwire, because window.githubSync is now a
+// real GitHubSync (#713) whose loadPublicData/loadPublicStats fetch the production
+// gist with no token required. Without this file, deleting that tripwire would leave
+// the suite green and the guard silently gone.
+
+describe('the no-network tripwire', () => {
+    it('refuses a request and names the URL', () => {
+        expect(() => fetch('https://api.github.com/gists/example'))
+            .toThrow(/must not make network calls.*api\.github\.com\/gists\/example/);
+
+        // Also drains the record, so the afterEach hook in setup.js does not fail
+        // this test for the call it was just asked to make.
+        expect(takeAttemptedRequests()).toEqual(['https://api.github.com/gists/example']);
+    });
+
+    it('records the attempt even when the caller swallows the error', async () => {
+        // The reason setup.js records attempts rather than only throwing: every fetch
+        // in github-sync.js sits in a try/catch that logs and returns null, so the
+        // throw alone vanishes and the call reads as an empty response. This asserts
+        // the swallowing really happens - if it ever stops, throwing would be enough
+        // and the record could go.
+        const stats = await globalThis.window.githubSync.loadPublicStats();
+        expect(stats).toEqual({});
+
+        expect(takeAttemptedRequests()).toHaveLength(1);
+    });
+
+    it('lets a test install its own fetch, and restores the tripwire after', () => {
+        const tripwire = globalThis.fetch;
+        globalThis.fetch = async () => ({ ok: true });
+        expect(() => fetch('https://example.test/allowed')).not.toThrow();
+        expect(takeAttemptedRequests()).toEqual([]);
+
+        globalThis.fetch = tripwire;
+        expect(() => fetch('https://example.test/blocked')).toThrow();
+        takeAttemptedRequests();
+    });
+});

--- a/tests/no-network.test.js
+++ b/tests/no-network.test.js
@@ -29,14 +29,25 @@ describe('the no-network tripwire', () => {
         expect(takeAttemptedRequests()).toHaveLength(1);
     });
 
-    it('lets a test install its own fetch, and restores the tripwire after', () => {
-        const tripwire = globalThis.fetch;
-        globalThis.fetch = async () => ({ ok: true });
-        expect(() => fetch('https://example.test/allowed')).not.toThrow();
+    // These two run in order and are a pair: the first deliberately leaves fetch
+    // clobbered so the second can prove setup.js re-arms it. Keep them adjacent, and
+    // keep the first one's missing restore - it is the point, not an oversight.
+    it('lets a test install its own fetch', async () => {
+        globalThis.fetch = async () => ({ ok: true, json: async () => ({ hello: 'world' }) });
+
+        // Awaited rather than `expect(() => fetch(...)).not.toThrow()`, which only
+        // catches a synchronous throw: an async stub always returns a Promise, so that
+        // form passes even when the stub rejects and proves nothing.
+        await expect(fetch('https://example.test/allowed')).resolves.toMatchObject({ ok: true });
         expect(takeAttemptedRequests()).toEqual([]);
 
-        globalThis.fetch = tripwire;
-        expect(() => fetch('https://example.test/blocked')).toThrow();
+        // Deliberately not restoring globalThis.fetch.
+    });
+
+    it('re-arms itself after a test that clobbered fetch without restoring', () => {
+        expect(() => fetch('https://example.test/blocked'))
+            .toThrow(/must not make network calls/);
+
         takeAttemptedRequests();
     });
 });

--- a/tests/setup.js
+++ b/tests/setup.js
@@ -1,3 +1,4 @@
+import { afterEach } from 'vitest';
 import { readFileSync } from 'fs';
 import { resolve } from 'path';
 import { createRequire } from 'module';
@@ -6,6 +7,41 @@ import { createRequire } from 'module';
 // Stub APIs that jsdom doesn't provide.
 globalThis.navigator.vibrate = () => {};
 globalThis.performance = globalThis.performance || { now: () => Date.now() };
+
+// No test may reach the network. This matters more now that github-sync.js is in the
+// list below: window.githubSync is a real GitHubSync, and loadPublicData /
+// loadPublicStats fetch the *production* gist without needing a token. A stray path
+// that used to die on `!window.githubSync` would otherwise quietly hit api.github.com.
+//
+// Throwing alone would not be enough, which is what the array is for: every fetch in
+// github-sync.js sits inside a try/catch that logs and returns null, so the thrown
+// error is swallowed and the call just looks like an empty response. Recording the
+// attempt and failing afterEach makes it unswallowable.
+//
+// A test that legitimately needs fetch assigns its own globalThis.fetch and never
+// reaches this one; restoring the previous value afterwards puts the tripwire back.
+const attemptedRequests = [];
+globalThis.fetch = (input) => {
+    const url = String(input && input.url ? input.url : input);
+    attemptedRequests.push(url);
+    throw new Error(`tests must not make network calls (attempted ${url})`);
+};
+
+// Returns the attempts since the last call, and clears them. Exported so
+// no-network.test.js can assert the tripwire is armed without tripping it.
+export function takeAttemptedRequests() {
+    return attemptedRequests.splice(0);
+}
+
+afterEach(() => {
+    const attempted = takeAttemptedRequests();
+    if (attempted.length) {
+        throw new Error(
+            'test attempted a network call; stub fetch for this path instead:\n  '
+            + attempted.join('\n  '),
+        );
+    }
+});
 
 // Load all shared modules into the jsdom global context so tests can access
 // CardRenderer, sanitizeText, sanitizeUrl, etc.

--- a/tests/setup.js
+++ b/tests/setup.js
@@ -19,13 +19,19 @@ globalThis.performance = globalThis.performance || { now: () => Date.now() };
 // attempt and failing afterEach makes it unswallowable.
 //
 // A test that legitimately needs fetch assigns its own globalThis.fetch and never
-// reaches this one; restoring the previous value afterwards puts the tripwire back.
+// reaches this one. It does not have to restore it: afterEach re-arms unconditionally,
+// so a test that forgets cannot leave every later test in the file unprotected.
+//
+// The cost of re-arming every time is that a stub installed in beforeAll, meant to
+// span several tests, is torn down after the first one. Nothing does that today;
+// install fetch stubs in beforeEach.
 const attemptedRequests = [];
-globalThis.fetch = (input) => {
+const tripwireFetch = (input) => {
     const url = String(input && input.url ? input.url : input);
     attemptedRequests.push(url);
     throw new Error(`tests must not make network calls (attempted ${url})`);
 };
+globalThis.fetch = tripwireFetch;
 
 // Returns the attempts since the last call, and clears them. Exported so
 // no-network.test.js can assert the tripwire is armed without tripping it.
@@ -34,6 +40,12 @@ export function takeAttemptedRequests() {
 }
 
 afterEach(() => {
+    // Re-arm before the check below, which throws: otherwise a test that both
+    // clobbered fetch and attempted a request would report the attempt and leave the
+    // tripwire disarmed. Re-arming does not touch the record, so an attempt is still
+    // reported exactly once.
+    globalThis.fetch = tripwireFetch;
+
     const attempted = takeAttemptedRequests();
     if (attempted.length) {
         throw new Error(

--- a/tests/setup.js
+++ b/tests/setup.js
@@ -1,5 +1,6 @@
 import { readFileSync } from 'fs';
 import { resolve } from 'path';
+import { createRequire } from 'module';
 
 // shared.js expects browser globals; jsdom provides document/window.
 // Stub APIs that jsdom doesn't provide.
@@ -9,18 +10,22 @@ globalThis.performance = globalThis.performance || { now: () => Date.now() };
 // Load all shared modules into the jsdom global context so tests can access
 // CardRenderer, sanitizeText, sanitizeUrl, etc.
 // Use indirect eval so declarations land in global scope (not a local function scope).
-const files = [
-    'shared.js',
-    'collapsible-sections.js',
-    'card-renderer.js',
-    'checklist-manager.js',
-    'image-editor.js',
-    'card-editor.js',
-    'shopping-list.js',
-    'nav.js',
-    'checklist-creator.js',
-    'checklist-engine.js',
-];
+//
+// The list comes from build-manifest.js, the same source build.js uses, rather
+// than being copied here - a test run that loads a different set of files than the
+// browser gets is testing a scope that does not ship. github-sync.js used to be
+// missing from this list, which meant the cross-file globals guard (#712) could not
+// resolve anything declared in it: a symbol there that was exported correctly would
+// still have failed that guard, and the only available fix would have been to load
+// the file here.
+//
+// checklist-engine.js is appended because build.js emits it as a *separate* bundle
+// that checklist.html loads on its own. It shares no scope with the concatenation at
+// runtime, so loading it alongside is a small infidelity, but tests exercise both
+// and nothing in either relies on the other being absent.
+const { sharedFiles, engineFile } = createRequire(import.meta.url)('../build-manifest.js');
+
+export const files = [...sharedFiles, engineFile];
 
 for (const file of files) {
     const code = readFileSync(resolve(import.meta.dirname, '..', 'src', file), 'utf-8');


### PR DESCRIPTION
Closes #713.

## The problem

`src/github-sync.js` was built into the bundle by `build.js` but absent from `tests/setup.js`'s eval list — two lists that must agree, with nothing enforcing or explaining the difference.

**The issue text understated it.** I wrote that the cross-file-globals guard from #712 "can't see that file". It actually scans `src/` with `readdirSync`, so it always saw it — the real defect was worse: a `const` there read cross-file would have **failed the guard even when correctly exported**, because the file was never loaded.

## The omission was incidental, not deliberate

Checked rather than assumed. `github-sync.js` does no network work at load — just `location.hostname`, three `localStorage.getItem` calls, and one `visibilitychange` listener. Including it works cleanly. A comment in `github-sync.test.js` claiming otherwise was wrong and is corrected.

## Fixed by removing the duplication, not policing it

A hardcoded expectation would be a third list to drift. Both `build.js` and `tests/setup.js` now require a new zero-dependency `build-manifest.js`.

Dependency-free is load-bearing: exporting the list from `build.js` directly pulls esbuild into jsdom, which hard-fails with `Invariant violation: TextEncoder`. `dist/` is byte-identical after the refactor (md5-checked).

`tests/bundle-file-lists.test.js` derives both lists programmatically — the manifest via `createRequire`, setup's via `import { files }` — and compares the data, not source text. It also asserts each file is **really loaded**, via its column-0 `window.X =` exports, because a list check alone would miss a file that's listed but fails to eval. It understands both bundles (`checklist-engine.js` is built separately, a legitimate difference rather than drift).

## Behaviour change, flagged

18 tests in `attribute-escaping` / `custom-filter-match` now reach the real `githubSync.isLoggedIn()` via `ChecklistManager.isOwner()`, where they previously short-circuited on `!window.githubSync`. Both paths return false (no token in localStorage, and no test writes one) — same result, different route. Verified with a Proxy singleton that throws on any property access, which also proved `.isLoggedIn` is the only property anything touches.

**No existing test was modified to accommodate the change.**

## A network tripwire, because the singleton is now real

`loadPublicData`/`loadPublicStats` fetch the **production** gist without a token. A stray path that used to die on `!window.githubSync` could now quietly hit `api.github.com`.

`tests/setup.js` now installs a `fetch` that records the attempt and throws, with `afterEach` failing on any recorded attempt.

The recording is the important half: **throwing alone would have been useless**, because every fetch in `github-sync.js` sits inside a `try/catch` that logs and returns `null` — so a thrown error is swallowed and the call just looks like an empty response. A test that legitimately needs `fetch` assigns its own and restores afterwards.

## Test plan

Nothing user-visible — test harness only, plus a corrected comment. The one production-adjacent change is `build-manifest.js`, and `dist/` is byte-identical, so a smoke check is enough:

- [ ] Site loads and a checklist page renders

587 tests (was 560). Non-vacuity: mutations caught include setup re-inlining a list without `github-sync.js` (the actual bug), an orphan `src/` file, and the manifest dropping `nav.js`.

Two mutations changed what shipped: a "names only files that exist" test turned out to be **unreachable** — a nonexistent manifest entry crashes setup before assertions run — so it was deleted along with a dead duplicate-check rather than left as green decoration.
