### PR TITLE
Include Auto in the generated search term for autographed cards

### DIFF
--- a/src/card-editor.js
+++ b/src/card-editor.js
@@ -659,11 +659,11 @@ class CardEditorModal {
                             ${this.collectionLinkHtml()}
                             <div class="card-editor-field full-width" id="editor-ebay-field">
                                 <label class="card-editor-label">eBay Search Term</label>
-                                <input type="text" class="card-editor-input" id="editor-ebay" placeholder="Defaults to player + set + number">
+                                <input type="text" class="card-editor-input" id="editor-ebay" placeholder="Defaults to player + set + number + variant/auto">
                             </div>
                             <div class="card-editor-field full-width" id="editor-price-search-field">
                                 <label class="card-editor-label">Price Search Term</label>
-                                <input type="text" class="card-editor-input" id="editor-price-search" placeholder="Defaults to player + set + number">
+                                <input type="text" class="card-editor-input" id="editor-price-search" placeholder="Defaults to player + set + number + variant/auto">
                             </div>
                         </div>
                         <div class="card-editor-field full-width card-editor-image-section">

--- a/src/card-renderer.js
+++ b/src/card-renderer.js
@@ -61,12 +61,17 @@ const CardRenderer = {
 
     // Build the default (unencoded) search string from card fields.
     // prefix is the resolved player name or configured fallback (may be empty).
-    // Includes the variant unless it is the "Base" variant, and "Auto" for
-    // autographed cards so eBay/price search results favor autographed listings.
+    // Includes the variant unless it is the "Base" variant, plus "Auto" for
+    // autographed cards - but only when set/variant don't already say so
+    // (e.g. "Rookie Signatures", "Autographics"). eBay's search ANDs every
+    // keyword, so appending "Auto" on top of wording that doesn't literally
+    // contain that word would require a token the real listing may lack.
     buildDefaultSearch(card, prefix = '') {
         const variant = (card.variant && card.variant !== 'Base') ? card.variant : '';
-        const auto = card.auto ? 'Auto' : '';
-        return `${prefix} ${card.set || ''} ${card.num || ''} ${variant} ${auto}`.replace(/\s+/g, ' ').trim();
+        const base = `${prefix} ${card.set || ''} ${card.num || ''} ${variant}`;
+        const alreadySaysAuto = /\b(auto|autos|autographs?|autographics|signatures?|signed)\b/i.test(base);
+        const auto = (card.auto && !alreadySaysAuto) ? 'Auto' : '';
+        return `${base} ${auto}`.replace(/\s+/g, ' ').trim();
     },
 
     // Generate eBay search URL

--- a/src/card-renderer.js
+++ b/src/card-renderer.js
@@ -61,10 +61,12 @@ const CardRenderer = {
 
     // Build the default (unencoded) search string from card fields.
     // prefix is the resolved player name or configured fallback (may be empty).
-    // Includes the variant unless it is the "Base" variant.
+    // Includes the variant unless it is the "Base" variant, and "Auto" for
+    // autographed cards so eBay/price search results favor autographed listings.
     buildDefaultSearch(card, prefix = '') {
         const variant = (card.variant && card.variant !== 'Base') ? card.variant : '';
-        return `${prefix} ${card.set || ''} ${card.num || ''} ${variant}`.replace(/\s+/g, ' ').trim();
+        const auto = card.auto ? 'Auto' : '';
+        return `${prefix} ${card.set || ''} ${card.num || ''} ${variant} ${auto}`.replace(/\s+/g, ' ').trim();
     },
 
     // Generate eBay search URL

--- a/tests/search-term.test.js
+++ b/tests/search-term.test.js
@@ -40,4 +40,16 @@ describe('CardRenderer.buildDefaultSearch', () => {
     it('handles a completely empty card', () => {
         expect(CardRenderer.buildDefaultSearch({}, '')).toBe('');
     });
+
+    it('appends Auto for an autographed card', () => {
+        const card = { set: '2024 Donruss', num: '#101', variant: 'Silver', auto: true };
+        expect(CardRenderer.buildDefaultSearch(card, 'Jayden Daniels'))
+            .toBe('Jayden Daniels 2024 Donruss #101 Silver Auto');
+    });
+
+    it('omits Auto when the card is not autographed', () => {
+        const card = { set: '2024 Donruss', num: '#101', auto: false };
+        expect(CardRenderer.buildDefaultSearch(card, 'Jayden Daniels'))
+            .toBe('Jayden Daniels 2024 Donruss #101');
+    });
 });

--- a/tests/search-term.test.js
+++ b/tests/search-term.test.js
@@ -48,8 +48,26 @@ describe('CardRenderer.buildDefaultSearch', () => {
     });
 
     it('omits Auto when the card is not autographed', () => {
-        const card = { set: '2024 Donruss', num: '#101', auto: false };
+        // The editor never submits auto: false - unchecked checkboxes are
+        // omitted entirely (see .claude/CLAUDE.md) - so this models the real shape.
+        const card = { set: '2024 Donruss', num: '#101' };
         expect(CardRenderer.buildDefaultSearch(card, 'Jayden Daniels'))
             .toBe('Jayden Daniels 2024 Donruss #101');
+    });
+
+    it('does not double up when the variant already says Auto', () => {
+        const card = { set: '2020 Panini Contenders', num: '#217', variant: 'Rookie Ticket Auto', auto: true };
+        expect(CardRenderer.buildDefaultSearch(card, 'Ben DiNucci'))
+            .toBe('Ben DiNucci 2020 Panini Contenders #217 Rookie Ticket Auto');
+    });
+
+    it('does not append Auto when the variant already says Autographs/Signatures', () => {
+        expect(CardRenderer.buildDefaultSearch(
+            { set: '2000 Sage', num: '#A23', variant: 'Autographs Red', auto: true }, 'Curtis Keaton'
+        )).toBe('Curtis Keaton 2000 Sage #A23 Autographs Red');
+
+        expect(CardRenderer.buildDefaultSearch(
+            { set: '2019 Panini National Treasures', num: '#185', variant: 'Rookie Signatures', auto: true }, 'Jimmy Moreland'
+        )).toBe('Jimmy Moreland 2019 Panini National Treasures #185 Rookie Signatures');
     });
 });


### PR DESCRIPTION
## Summary
- `buildDefaultSearch` already appends the card's variant (e.g. "Silver") unless it's "Base"; this does the same for `card.auto`, appending "Auto" so the generated eBay/price search links for an autographed card surface autographed listings - but only when the set/variant don't already convey that (e.g. "Rookie Signatures", "Autographics", "Certified Autograph Issue"). eBay's search ANDs every keyword, so appending "Auto" unconditionally would require a token some real listings don't literally contain.
- Only affects the *generated* default search term - cards with an explicit `search`/`priceSearch` override are unaffected, same as variant already works.
- Updated the two stale "Defaults to player + set + number" placeholders in the card editor's advanced fields to mention variant/auto too.

## Review
Ran the `tech-lead-reviewer` adversarial review before opening this. It caught that an unconditional append was net-harmful - pulled the live gist data and found 4 of 7 real autographed cards (`jmu-pro-players`) have autograph wording that doesn't contain the literal word "Auto" (would've broken their eBay search), and the other 3 already say "Auto" (would've just gotten a cosmetic duplicate). Fixed by only appending when the assembled string doesn't already say so, and added tests using those real collision shapes instead of a synthetic one.

## Test plan
- [x] `npm test` (via node 22 locally): 38 files / 741 tests pass, including 6 in `search-term.test.js` covering the append, the omission when absent, and the two real-world collision shapes
- [x] Verified against the live gist: replayed the function over all 7 real autographed cards - no more double "Auto", no more spurious required tokens
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)